### PR TITLE
docs: add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Please do NOT open a public GitHub issue for security vulnerabilities.**
+
+If you discover a security vulnerability in PrepIQ, please report
+it responsibly by emailing the maintainer directly via the contact
+on their GitHub profile.
+
+### What to Include
+
+- Clear description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact assessment
+- Suggested fix (optional)
+
+### What to Expect
+
+- Acknowledgement within **48 hours**
+- Status update within **7 days**
+- Credit in release notes if desired
+
+## Best Practices for Contributors
+
+- Never commit `.env` files or real API keys
+- Use `.env.example` for sharing environment variable names
+- Never hardcode secrets in source code
+
+Thank you for helping keep PrepIQ secure! 🔒


### PR DESCRIPTION
## What does this PR do?
Adds SECURITY.md with a clear, practical vulnerability
reporting policy as requested in issue #9.

## Related Issue
Closes #9

## Type of change
- [x] Documentation update

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] No functional code changes
- [x] Addresses all acceptance criteria in the issue