### PR TITLE
docs: add SECURITY.md policy (#9)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you find a security vulnerability in PrepIQ, please do not report it through public GitHub issues or discussions.
+
+Instead, report the issue privately by contacting the maintainers through GitHub.
+
+When submitting a report, please include the following:
+- A clear description of the vulnerability
+- Steps to reproduce the issue
+- The potential impact, if known
+- Possible fixes or suggestions (optional)
+
+## Response Process
+
+The maintainers will review valid security reports as soon as possible and work on an appropriate fix before any public disclosure when necessary.
+
+Thank you for helping keep PrepIQ and its community safe.


### PR DESCRIPTION
## Summary

- Added a `SECURITY.md` file to document the process for responsibly reporting security vulnerabilities.
- Clarified that sensitive security issues should not be reported through public GitHub issues.
- Included practical guidance for reporting vulnerabilities privately to maintainers.

## Validation

- [ ] `npm run build`
- [ ] `npx tsc --noEmit`
- [ ] `python -m compileall backend`

## Screenshots

Not applicable — documentation-only change.

## Risks

No migration, deployment, or API risks. This PR only adds project documentation.
