### PR TITLE
Add Python backend CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,19 @@ jobs:
 
   backend:
     runs-on: ubuntu-latest
+    name: Backend (Python ${{ matrix.python-version }})
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python
+      - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install backend dependencies
         run: python -m pip install -r backend/requirements.txt


### PR DESCRIPTION
## Summary
- Convert the backend CI job into a Python version matrix.
- Run the existing backend dependency install, compile, and unittest steps on Python 3.10 and 3.11.
- Name each backend job with its Python version so failures are easier to identify.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `python3 -m compileall backend`
- `git diff --check`

Note: I attempted the full backend test command locally after installing `backend/requirements.txt`, but the macOS system Python 3.9 environment tried to build a yanked spaCy source package from source. The updated GitHub Actions matrix uses Python 3.10/3.11, which is the intended environment for validating the full dependency install and tests.

Fixes #21