### PR TITLE
fix(sidebar): close mobile drawer after navigation

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -36,7 +36,7 @@ interface AppSidebarProps {
 }
 
 export function AppSidebar({ onLogout }: AppSidebarProps) {
-  const { state } = useSidebar();
+  const { state, setOpenMobile } = useSidebar();
   const collapsed = state === "collapsed";
   const location = useLocation();
 
@@ -64,6 +64,7 @@ export function AppSidebar({ onLogout }: AppSidebarProps) {
                     <NavLink
                       to={item.url}
                       end
+                      onClick={() => setOpenMobile(false)}
                       className="hover:bg-sidebar-accent/50 transition-colors"
                       activeClassName="bg-sidebar-accent text-sidebar-primary font-medium"
                     >


### PR DESCRIPTION
## Summary

This closes #32 

- What problem does this PR solve?
    - After loging the user is redirected to the dashboard where he uses the sidebar to navigate to other pages. This works fine in desktop but in mobile when we open the sidebar and then click on another page then that page opens but the sidebar remains open too. 
- What changed?
    - Now in the mobile when a user clicks on the sidebar then selects another page then the sidebar automatically closes and the user sees the new loaded page. 

## Validation

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [ ] `python -m compileall backend` (No backend changes done so not required)

## Screenshots

Before:
<img width="272" height="588" alt="ezgif-462289f6c026929e" src="https://github.com/user-attachments/assets/b49296eb-f584-4281-bf91-ae79f46d1b4d" />

After:
<img width="268" height="580" alt="ezgif-4a74b3d267c140a9" src="https://github.com/user-attachments/assets/8d18eca9-7fa7-46c3-a32a-e53646548a0c" />



## Risks

NA

AI Usage: AI was used to write commit message. AI was not used to write code or PR description. 

Kindly please add all the appropriate GSSoC'26 labels to this PR (approved, difficulty and type labels) so it can count towards my contribution. Thanks!
