### PR TITLE
Fix multi-word skill extraction in ml.py

### DIFF
--- a/backend/app/ml.py
+++ b/backend/app/ml.py
@@ -98,15 +98,29 @@ def extract_skills(text: str) -> list[str]:
 
     found_skills: set[str] = set()
     text_lower = text.lower()
+    # Normalize separators and spacing for multi-word skill matching
+    normalized_text = re.sub(r'[-_/]', ' ', text_lower)
+    normalized_text = re.sub(r'\s+', ' ', normalized_text).strip()
 
+    
     # Method 1: Keyword matching against curated skill list
-    for skill in TECH_SKILLS:
-        # Use word boundary matching to avoid partial matches
-        pattern = r'\b' + re.escape(skill) + r'\b'
-        if re.search(pattern, text_lower):
-            # Store with proper capitalization
-            found_skills.add(skill.title() if len(skill) > 3 else skill.upper())
+    for skill in sorted(TECH_SKILLS, key=len, reverse=True):
+        # Multi-word skills need safer boundary handling
+        if ' ' in skill:
+            pattern = r'(?<!\w)' + re.escape(skill) + r'(?!\w)'
+        else:
+            pattern = r'\b' + re.escape(skill) + r'\b'
 
+        if re.search(pattern, normalized_text):
+
+            # Avoid adding shorter overlapping skills
+            if any(skill in existing.lower() for existing in found_skills):
+                continue
+
+            found_skills.add(
+                skill.title() if len(skill) > 3 else skill.upper()
+            )
+            
     # Method 2: spaCy NER to catch additional entities
     nlp = _get_spacy()
     if nlp:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -59,6 +59,34 @@ class PrepIQApiTestCase(unittest.TestCase):
         self.assertIsInstance(payload["skills"], list)
         self.assertEqual(payload["count"], len(payload["skills"]))
         self.assertIn("Python", payload["skills"])
+    
+    def test_extract_skills_endpoint_returns_multiword_skills(self) -> None:
+        from backend.app import ml
+
+        ml._spacy_nlp = False
+
+        response = self.client.post(
+            "/api/ml/extract-skills",
+            json={
+                "text": """
+                Worked on machine-learning, spring_boot,
+                oauth/jwt auth, and google-cloud deployment
+                """
+            },
+        )
+
+        self.assertEqual(response.status_code, 200, response.text)
+
+        payload = response.json()
+        skills = payload["skills"]
+
+        self.assertIn("Machine Learning", skills)
+        self.assertIn("Spring Boot", skills)
+        self.assertIn("Google Cloud", skills)
+
+        # Single-word skills should still work
+        self.assertIn("Oauth", skills)
+        self.assertIn("JWT", skills)
 
     def test_match_score_endpoint_returns_score_and_label(self) -> None:
         response = self.client.post(


### PR DESCRIPTION
Fixes #18
## Summary

Improved multi-word skill extraction logic in `ml.py` by adding safer regex boundary handling and normalization support.

This fixes missing detections for skills such as:

* Machine Learning
* Spring Boot
* Google Cloud

## Changes Made

* Added normalized text matching for `-`, `_`, and `/`
* Improved regex handling for multi-word skills
* Prevented overlapping shorter skill matches
* Preserved existing single-word skill matching behavior

## Testing

Tested locally using:

```python
extract_skills("""
Worked on machine-learning, spring_boot,
oauth/jwt auth, and google-cloud deployment
""")
```

Output:

```json
[
  "Google Cloud",
  "JWT",
  "Machine Learning",
  "Oauth",
  "Spring Boot"
]
```

Additional automated API test added in:

```text
backend/tests/test_api.py
```

Validation completed successfully:

* `python3 -m unittest backend.tests.test_api`
* All tests passing
