### PR TITLE
Fix ScoreCircle bounds and 404 navigation

### DIFF
--- a/src/components/ScoreCircle.tsx
+++ b/src/components/ScoreCircle.tsx
@@ -5,44 +5,53 @@ interface ScoreCircleProps {
 }
 
 export function ScoreCircle({ score, size = 160, label = "Readiness" }: ScoreCircleProps) {
+  const safeScore = Number.isFinite(score) ? score : 0;
+  const clampedScore = Math.min(100, Math.max(0, safeScore));
   const radius = (size - 16) / 2;
   const circumference = 2 * Math.PI * radius;
-  const offset = circumference - (score / 100) * circumference;
+  const offset = circumference - (clampedScore / 100) * circumference;
 
   const color =
-    score >= 80
+    clampedScore >= 80
       ? "hsl(var(--success))"
-      : score >= 50
+      : clampedScore >= 50
       ? "hsl(var(--warning))"
       : "hsl(var(--destructive))";
 
   return (
     <div className="flex flex-col items-center gap-2">
-      <svg width={size} height={size} className="transform -rotate-90">
-        <circle
-          cx={size / 2}
-          cy={size / 2}
-          r={radius}
-          stroke="hsl(var(--border))"
-          strokeWidth="8"
-          fill="none"
-        />
-        <circle
-          cx={size / 2}
-          cy={size / 2}
-          r={radius}
-          stroke={color}
-          strokeWidth="8"
-          fill="none"
-          strokeLinecap="round"
-          strokeDasharray={circumference}
-          strokeDashoffset={offset}
-          className="transition-all duration-1000 ease-out"
-        />
-      </svg>
-      <div className="absolute flex flex-col items-center" style={{ marginTop: size / 2 - 20 }}>
-        <span className="text-3xl font-bold text-foreground">{score}%</span>
-        <span className="text-xs text-muted-foreground">{label}</span>
+      <div
+        className="relative flex items-center justify-center"
+        style={{ width: size, height: size }}
+      >
+        <svg width={size} height={size} className="transform -rotate-90">
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            stroke="hsl(var(--border))"
+            strokeWidth="8"
+            fill="none"
+          />
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            stroke={color}
+            strokeWidth="8"
+            fill="none"
+            strokeLinecap="round"
+            strokeDasharray={circumference}
+            strokeDashoffset={offset}
+            className="transition-all duration-1000 ease-out"
+          />
+        </svg>
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span className="text-3xl font-bold text-foreground">
+            {Math.round(clampedScore)}%
+          </span>
+          <span className="text-xs text-muted-foreground">{label}</span>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,5 @@
-import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { Link, useLocation } from "react-router-dom";
 
 const NotFound = () => {
   const location = useLocation();
@@ -13,9 +13,9 @@ const NotFound = () => {
       <div className="text-center">
         <h1 className="mb-4 text-4xl font-bold">404</h1>
         <p className="mb-4 text-xl text-muted-foreground">Oops! Page not found</p>
-        <a href="/" className="text-primary underline hover:text-primary/90">
+        <Link to="/" className="text-primary underline hover:text-primary/90">
           Return to Home
-        </a>
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- clamp ScoreCircle values to the 0-100 range before computing SVG progress or display text
- give the circular score overlay a relative parent so the absolute center content is positioned correctly
- replace the 404 page anchor with React Router `Link` for SPA navigation

Fixes #34

## Testing
- `git diff --check` ✅

## Note
I could not run the Vite/Vitest scripts locally in this Codex shell because this checkout has no `node_modules` installed and no package manager binary (`npm`, `pnpm`, `yarn`, or `corepack`) available on PATH. The change is limited to two frontend files and keeps the existing visual classes intact.

## GSSoC labels requested
Please add `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug` if this PR meets the project criteria.
