### PR TITLE
Improve sidebar and layout accessibility

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -10,12 +10,22 @@ export function AppLayout({ children, onLogout }: AppLayoutProps) {
   return (
     <SidebarProvider>
       <div className="min-h-screen flex w-full">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-background focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-foreground focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          Skip to content
+        </a>
         <AppSidebar onLogout={onLogout} />
         <div className="flex-1 flex flex-col min-w-0">
           <header className="h-14 flex items-center border-b border-border px-4 glass sticky top-0 z-10">
             <SidebarTrigger className="mr-4" />
           </header>
-          <main className="flex-1 p-4 md:p-6 lg:p-8 overflow-auto">
+          <main
+            id="main-content"
+            tabIndex={-1}
+            className="flex-1 p-4 md:p-6 lg:p-8 overflow-auto"
+          >
             {children}
           </main>
         </div>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -60,6 +60,7 @@ export function AppSidebar({ onLogout }: AppSidebarProps) {
                   <SidebarMenuButton
                     asChild
                     isActive={location.pathname === item.url}
+                    tooltip={item.title}
                   >
                     <NavLink
                       to={item.url}
@@ -67,6 +68,7 @@ export function AppSidebar({ onLogout }: AppSidebarProps) {
                       onClick={() => setOpenMobile(false)}
                       className="hover:bg-sidebar-accent/50 transition-colors"
                       activeClassName="bg-sidebar-accent text-sidebar-primary font-medium"
+                      aria-label={item.title}
                     >
                       <item.icon className="mr-2 h-4 w-4 shrink-0" />
                       {!collapsed && <span>{item.title}</span>}
@@ -82,7 +84,12 @@ export function AppSidebar({ onLogout }: AppSidebarProps) {
       <SidebarFooter className="border-t border-border p-2">
         <SidebarMenu>
           <SidebarMenuItem>
-            <SidebarMenuButton onClick={onLogout} className="hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors">
+            <SidebarMenuButton
+              onClick={onLogout}
+              className="hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors"
+              tooltip="Logout"
+              aria-label="Logout"
+            >
               <LogOut className="mr-2 h-4 w-4 shrink-0" />
               {!collapsed && <span>Logout</span>}
             </SidebarMenuButton>


### PR DESCRIPTION
## Summary
- enable existing sidebar tooltips for each navigation item and logout action while collapsed
- add accessible labels to icon-only sidebar controls
- add a keyboard-visible skip link that jumps directly to the main content region

Fixes #35

## Testing
- `git diff --check` ✅

## Note
I could not run the Vite/Vitest scripts locally in this Codex shell because this checkout has no `node_modules` installed and no package manager binary (`npm`, `pnpm`, `yarn`, or `corepack`) available on PATH. The change is limited to two layout/sidebar components and uses existing UI primitives.

## GSSoC labels requested
Please add `gssoc:approved`, `level:beginner`, `quality:clean`, `type:accessibility`, and `type:feature` if this PR meets the project criteria.
