### PR TITLE
test: add auth failure cases for wrong password, expired token, and cross-user access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ venv/
 *.njsproj
 *.sln
 *.sw?
+
+backend/test-ci.db

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -115,6 +115,53 @@ class PrepIQApiTestCase(unittest.TestCase):
         tampered_me = self.client.get("/api/auth/me", headers={"Authorization": f"Bearer {tampered_token}"})
         self.assertEqual(tampered_me.status_code, 401, tampered_me.text)
 
+    def test_login_wrong_password_returns_401(self) -> None:
+        email = f"wrongpw-{uuid4().hex[:8]}@example.com"
+        self.client.post(
+            "/api/auth/signup",
+            json={"name": "Wrong PW User", "email": email, "password": "password123"},
+        )
+
+        response = self.client.post(
+            "/api/auth/login",
+            json={"email": email, "password": "wrongpassword"},
+        )
+
+        self.assertEqual(response.status_code, 401, response.text)
+        self.assertIn("Invalid credentials", response.json()["detail"])
+
+    def test_expired_token_returns_401(self) -> None:
+        from datetime import timedelta
+        from backend.app.main import encode_token, utc_now
+
+        user_id, _ = self.create_account()
+
+        expired_token = encode_token({
+            "sub": user_id,
+            "email": "expired@example.com",
+            "exp": int((utc_now() - timedelta(hours=1)).timestamp()),
+        })
+
+        response = self.client.get(
+            f"/api/users/{user_id}/sessions",
+            headers={"Authorization": f"Bearer {expired_token}"},
+        )
+
+        self.assertEqual(response.status_code, 401, response.text)
+        self.assertIn("Token expired", response.json()["detail"])
+
+    def test_cross_user_access_returns_403(self) -> None:
+        user_a_id, _ = self.create_account()
+        user_b_id, headers_b = self.create_account()
+
+        response = self.client.get(
+            f"/api/users/{user_a_id}/profile",
+            headers=headers_b,
+        )
+
+        self.assertEqual(response.status_code, 403, response.text)
+        self.assertIn("Forbidden", response.json()["detail"])
+
     def test_profile_session_mock_and_job_flow(self) -> None:
         user_id, headers = self.create_account()
 


### PR DESCRIPTION
Closes #10 

## Summary
- Added three missing auth failure test cases to the backend test suite to catch regressions in authentication behavior.

## Changes
- Added `test_login_wrong_password_returns_401` - verifies wrong password returns 401 with "Invalid credentials"
- Added `test_expired_token_returns_401` - verifies an expired token returns 401 with "Token expired"
- Added `test_cross_user_access_returns_403` - verifies User B accessing User A's data returns 403 with "Forbidden"
- Added test-ci.db to .gitignore (test artifact - created by test runs, should not be tracked)

## How to test
```bash
python -m unittest discover -s backend/tests -p "test_*.py"
```
All 9 tests should pass (6 existing + 3 new).

## Acceptance Criteria
- [x] Wrong password returns 401
- [x] Expired token returns 401
- [x] Cross-user access returns 403
- [x] Tests assert both status codes and meaningful error details
- [x] Existing tests continue to pass


## Screenshot

<img width="935" height="383" alt="image" src="https://github.com/user-attachments/assets/3b6ae443-28cf-4ed5-8b41-394dcc73397e" />
