### PR TITLE
feat: add light/dark/system theme toggle with next-themes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Suspense, lazy, Component } from "react";
 import type { ReactNode, ErrorInfo } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Route, Routes, Navigate } from "react-router-dom";
+import { ThemeProvider } from "next-themes";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AppLayout } from "@/components/AppLayout";
@@ -123,14 +124,16 @@ function AppRoutes() {
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <ErrorBoundary>
-        <BrowserRouter>
-          <AppRoutes />
-        </BrowserRouter>
-      </ErrorBoundary>
-    </TooltipProvider>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+      <TooltipProvider>
+        <Toaster />
+        <ErrorBoundary>
+          <BrowserRouter>
+            <AppRoutes />
+          </BrowserRouter>
+        </ErrorBoundary>
+      </TooltipProvider>
+    </ThemeProvider>
   </QueryClientProvider>
 );
 

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -7,7 +7,11 @@ import {
   TrendingUp,
   LogOut,
   Sparkles,
+  Sun,
+  Moon,
+  SunMoon,
 } from "lucide-react";
+import { useTheme } from "next-themes";
 import { NavLink } from "@/components/NavLink";
 import { useLocation } from "react-router-dom";
 import {
@@ -37,6 +41,26 @@ interface AppSidebarProps {
 
 export function AppSidebar({ onLogout }: AppSidebarProps) {
   const { state, setOpenMobile } = useSidebar();
+  const { theme, setTheme } = useTheme();
+
+  const toggleTheme = () => {
+    const order = ["light", "dark", "system"] as const;
+    const currentIndex = order.indexOf(theme as "light" | "dark" | "system");
+    const nextIndex = (currentIndex + 1) % order.length;
+    setTheme(order[nextIndex]);
+  };
+
+  const themeIcon = {
+    light: <Sun className="mr-2 h-4 w-4 shrink-0" />,
+    dark: <Moon className="mr-2 h-4 w-4 shrink-0" />,
+    system: <SunMoon className="mr-2 h-4 w-4 shrink-0" />,
+  }[theme === "dark" ? "dark" : theme === "light" ? "light" : "system"];
+
+  const themeLabel = {
+    light: "Light",
+    dark: "Dark",
+    system: "System",
+  }[theme === "dark" ? "dark" : theme === "light" ? "light" : "system"];
   const collapsed = state === "collapsed";
   const location = useLocation();
 
@@ -81,6 +105,12 @@ export function AppSidebar({ onLogout }: AppSidebarProps) {
 
       <SidebarFooter className="border-t border-border p-2">
         <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton onClick={toggleTheme} className="hover:bg-accent/50 text-muted-foreground hover:text-foreground transition-colors">
+              {themeIcon}
+              {!collapsed && <span>{themeLabel}</span>}
+            </SidebarMenuButton>
+          </SidebarMenuItem>
           <SidebarMenuItem>
             <SidebarMenuButton onClick={onLogout} className="hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors">
               <LogOut className="mr-2 h-4 w-4 shrink-0" />

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,62 @@
 
 @layer base {
   :root {
+    --background: 0 0% 100%;
+    --foreground: 230 25% 10%;
+
+    --card: 220 20% 98%;
+    --card-foreground: 230 25% 10%;
+
+    --popover: 0 0% 100%;
+    --popover-foreground: 230 25% 10%;
+
+    --primary: 245 58% 55%;
+    --primary-foreground: 0 0% 100%;
+
+    --secondary: 230 15% 94%;
+    --secondary-foreground: 230 20% 20%;
+
+    --muted: 230 12% 94%;
+    --muted-foreground: 230 10% 45%;
+
+    --accent: 245 55% 93%;
+    --accent-foreground: 245 58% 40%;
+
+    --destructive: 0 72% 50%;
+    --destructive-foreground: 0 0% 100%;
+
+    --success: 152 55% 38%;
+    --success-foreground: 0 0% 100%;
+
+    --warning: 38 90% 50%;
+    --warning-foreground: 0 0% 10%;
+
+    --border: 230 12% 88%;
+    --input: 230 12% 88%;
+    --ring: 245 58% 55%;
+
+    --radius: 0.75rem;
+
+    --sidebar-background: 230 18% 97%;
+    --sidebar-foreground: 230 10% 40%;
+    --sidebar-primary: 245 58% 55%;
+    --sidebar-primary-foreground: 0 0% 100%;
+    --sidebar-accent: 230 15% 93%;
+    --sidebar-accent-foreground: 230 20% 15%;
+    --sidebar-border: 230 10% 90%;
+    --sidebar-ring: 245 58% 55%;
+
+    --gradient-primary: linear-gradient(135deg, hsl(245 58% 55%), hsl(280 55% 50%));
+    --gradient-accent: linear-gradient(135deg, hsl(245 58% 55%), hsl(200 65% 50%));
+    --gradient-success: linear-gradient(135deg, hsl(152 55% 38%), hsl(170 50% 38%));
+    --gradient-warm: linear-gradient(135deg, hsl(38 90% 50%), hsl(15 75% 50%));
+
+    --shadow-glow: 0 0 25px -5px hsl(245 58% 55% / 0.15);
+    --shadow-card: 0 4px 24px -4px hsl(0 0% 0% / 0.08);
+    --shadow-elevated: 0 8px 40px -8px hsl(0 0% 0% / 0.12);
+  }
+
+  .dark {
     --background: 230 25% 7%;
     --foreground: 220 20% 92%;
 
@@ -39,8 +95,6 @@
     --border: 230 15% 18%;
     --input: 230 15% 18%;
     --ring: 245 58% 62%;
-
-    --radius: 0.75rem;
 
     --sidebar-background: 230 25% 9%;
     --sidebar-foreground: 220 12% 65%;


### PR DESCRIPTION
Closes #42

## Summary
- Added a theme toggle supporting dark, light, and system themes using `next-themes`. Theme preference persists in localStorage across sessions.

## Changes
- Updated `src/index.css` - moved dark mode values to `.dark` selector and added light mode values to `:root`
- Updated `src/App.tsx` - wrapped app with `ThemeProvider` from `next-themes` (`attribute="class"`, `defaultTheme="system"`, `enableSystem`)
- Updated `src/components/AppSidebar.tsx` - added theme toggle button in sidebar footer that cycles Dark → Light → System with corresponding icons (Moon, Sun, SunMoon)

## How to test
1. Open the app and click the theme toggle in the sidebar footer
2. Verify it cycles through Dark → Light → System
3. Verify light mode renders correctly on all pages
4. Refresh the page - selected theme persists
5. Set to "System" and change your OS theme — app follows the OS preference

## Acceptance Criteria
- [x] User can switch between dark, light, and system themes
- [x] Selected theme persists after page refresh
- [x] All pages render correctly in light mode without broken styles
- [x] Toggle is accessible from the sidebar
- [x] System preference is respected on first visit

## Screenshots

<img width="1707" height="988" alt="image" src="https://github.com/user-attachments/assets/b0a68760-6b13-40de-86c7-a47670e31917" />

<img width="1684" height="984" alt="image" src="https://github.com/user-attachments/assets/a1526687-bda4-4861-ac29-ff6afac9c4cb" />

<img width="135" height="114" alt="image" src="https://github.com/user-attachments/assets/0ec620ce-1596-4cb2-bf75-27a1de3f7a81" />

<img width="144" height="104" alt="image" src="https://github.com/user-attachments/assets/403f257a-312d-43da-a8a5-d70bf644bbb4" />

<img width="323" height="128" alt="image" src="https://github.com/user-attachments/assets/ea67c01c-92b4-449e-9d81-c9c15ea755df" />
