### PR TITLE
Add interview focus areas to Career DNA

### DIFF
--- a/src/pages/CareerDNAPage.tsx
+++ b/src/pages/CareerDNAPage.tsx
@@ -36,6 +36,10 @@ export default function CareerDNAPage({ user, profile }: CareerDNAPageProps) {
     </div>
   );
 
+  const interviewFears = profile.interviewFears ?? [];
+  const fearNotes = profile.fearNotes?.trim() ?? "";
+  const hasInterviewFocus = interviewFears.length > 0 || fearNotes.length > 0;
+
   return (
     <div className="space-y-6 animate-slide-up">
       <div className="flex items-center justify-between">
@@ -105,6 +109,21 @@ export default function CareerDNAPage({ user, profile }: CareerDNAPageProps) {
             </div>
           </div>
         </Section>
+
+        {hasInterviewFocus && (
+          <Section title="Interview Focus Areas">
+            <div className="space-y-3 text-sm">
+              {interviewFears.length > 0 && (
+                <div className="flex flex-wrap gap-1.5">
+                  {interviewFears.map((fear) => (
+                    <Badge key={fear} variant="outline" className="text-xs">{fear}</Badge>
+                  ))}
+                </div>
+              )}
+              {fearNotes && <p className="text-muted-foreground">{fearNotes}</p>}
+            </div>
+          </Section>
+        )}
       </div>
 
       <Button onClick={() => navigate("/onboarding")} variant="outline">


### PR DESCRIPTION
## Summary

- Fixes a display gap where interview fears and notes collected during onboarding were not shown on the Career DNA page.
- Added an Interview Focus Areas section that displays selected interview fears as badges and shows fear notes only when notes are non-empty.
- The section is hidden when there are no selected fears and no notes, so empty profile data does not create a blank card.
Closes #45
## Validation

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [ ] `python -m compileall backend` - not run; frontend-only change
- [x] `npm run lint` - passed with existing unrelated warnings
- [x] `npm test`

## Screenshots

<img width="1440" height="771" alt="Screenshot 2026-05-17 at 9 26 11 PM" src="https://github.com/user-attachments/assets/1f9ed0af-3679-4132-825c-6874a76bf7d0" />


## Risks

No migration, deployment, backend, or API concerns. This is a frontend-only display change using existing profile fields.