### PR TITLE
fix: display Avg Mock Score as X/100 instead of X%

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -83,7 +83,7 @@ export default function DashboardPage({ user, profile, sessions, mocks, jobs }: 
         <StatCard icon={BookOpen} label="Prep Sessions" value={sessions.length} />
         <StatCard icon={MessageSquare} label="Mock Interviews" value={mocks.length} gradient="gradient-accent" />
         <StatCard icon={Briefcase} label="Jobs Applied" value={jobs.length} gradient="gradient-warm" />
-        <StatCard icon={TrendingUp} label="Avg Mock Score" value={`${avgScore}%`} gradient="gradient-success" />
+        <StatCard icon={TrendingUp} label="Avg Mock Score" value={`${avgScore}/100`} gradient="gradient-success" />
       </div>
 
       {/* Quick Actions */}


### PR DESCRIPTION
## Problem
The Avg Mock Score stat card on the Dashboard displays the score 
with a `%` suffix (e.g. `60%`), which implies it is a percentage. 
Mock interview scores are out of 100, not percentages, so this is 
misleading and inconsistent with the other three stat cards (Prep 
Sessions, Mock Interviews, Jobs Applied) which all display plain numbers.

## Changes Made
- Changed `value={\`${avgScore}%\`}` to `value={\`${avgScore}/100\`}` 
  in `src/pages/DashboardPage.tsx`

## Before & After
| Before | After |
|--------|-------|
| `60%`  | `60/100` |

## Type of Change
- [x] Bug fix

## Testing
- Navigated to Dashboard after completing a mock interview
- Avg Mock Score now displays as `60/100` instead of `60%`