### PR TITLE
fix(TagInput): add paste handling for comma-separated values

### DIFF
--- a/src/components/TagInput.tsx
+++ b/src/components/TagInput.tsx
@@ -1,4 +1,4 @@
-import { useState, KeyboardEvent } from "react";
+import { useState, KeyboardEvent, ClipboardEvent } from "react";
 import { X } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -15,7 +15,7 @@ export function TagInput({ tags, onChange, placeholder = "Type and press Enter..
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter" && input.trim()) {
       e.preventDefault();
-      if (!tags.includes(input.trim())) {
+     if (!tags.some((t) => t.toLowerCase() === input.trim().toLowerCase())) {
         onChange([...tags, input.trim()]);
       }
       setInput("");
@@ -24,6 +24,26 @@ export function TagInput({ tags, onChange, placeholder = "Type and press Enter..
       onChange(tags.slice(0, -1));
     }
   };
+  const handlePaste = (e: ClipboardEvent<HTMLInputElement>) => {
+  e.preventDefault();
+  const pasted = e.clipboardData.getData("text");
+  
+  const newTags = pasted
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);  // removes empty strings
+  
+  const existingLower = tags.map((t) => t.toLowerCase());
+  
+  const unique = newTags.filter(
+    (t) => !existingLower.includes(t.toLowerCase())
+  );
+  
+  if (unique.length > 0) {
+    onChange([...tags, ...unique]);
+  }
+  setInput("");
+};
 
   return (
     <div className="flex flex-wrap gap-2 p-2 rounded-lg border border-input bg-secondary/50 min-h-[42px]">
@@ -44,6 +64,7 @@ export function TagInput({ tags, onChange, placeholder = "Type and press Enter..
         value={input}
         onChange={(e) => setInput(e.target.value)}
         onKeyDown={handleKeyDown}
+        onPaste={handlePaste} 
         placeholder={tags.length === 0 ? placeholder : ""}
         className="flex-1 min-w-[120px] border-0 bg-transparent p-0 h-auto focus-visible:ring-0 text-sm"
       />


### PR DESCRIPTION
<html>
<body>
<h2>Close #44 </h2>
<hr>
<h2>Summary</h2>
<p><strong>What problem does this PR solve?</strong>
<code>TagInput</code> only added one tag at a time using Enter. Users who pasted comma-separated values like <code>React, TypeScript, SQL</code> got no result — the paste was ignored entirely.</p>
<p><strong>What changed?</strong></p>
<ul>
<li>Added <code>handlePaste</code> to <code>src/components/TagInput.tsx</code> that splits pasted text by comma, trims each entry, filters empty values, and deduplicates case-insensitively before calling <code>onChange</code></li>
<li>Fixed the existing Enter key duplicate check from <code>tags.includes()</code> (case-sensitive) to <code>tags.some()</code> with <code>toLowerCase()</code> (case-insensitive) — consistent with paste behavior</li>
<li>Imported <code>ClipboardEvent</code> as a named import from <code>"react"</code> instead of using <code>React.ClipboardEvent</code></li>
<li>Wired <code>onPaste={handlePaste}</code> to the <code>&lt;Input&gt;</code> element</li>
</ul>
<hr>
<h2>Validation</h2>
<ul>
<li>[ ] <code>npm run build</code></li>
<li>[ ] <code>npx tsc --noEmit</code></li>
<li>[ ] <code>python -m compileall backend</code></li>
</ul>
<p><strong>Manual tests performed:</strong></p>

Test case | Expected | Result
-- | -- | --
Paste React, TypeScript, SQL | 3 separate tags created | ✅
Paste react when React already exists | Duplicate ignored | ✅
Paste React, , SQL | 2 tags, empty entry skipped | ✅
Press Enter to add a tag | Works as before | ✅
Press Backspace to remove last tag | Works as before | ✅


<hr>
<h2>Screenshots</h2>
<blockquote>
<p>Paste <code>React, TypeScript, SQL</code> → three badges appear instantly without pressing Enter.</p>
</blockquote>
<p>

https://github.com/user-attachments/assets/09378f2f-0ee7-4f8e-bb3c-e1973209a2c4

</p>
<hr>
<h2>Risks</h2>
<ul>
<li><strong>None.</strong> Change is isolated to <code>src/components/TagInput.tsx</code> only</li>
<li>No API changes, no database migrations, no backend impact</li>
<li>Fully backward compatible — Enter and Backspace behavior unchanged</li>
<li>No new dependencies added</li>
</ul></body></html><!--EndFragment-->
</body>
</html>