### PR TITLE
feat: Add colored status chips to job tracker table view

### DIFF
--- a/src/pages/JobTrackerPage.tsx
+++ b/src/pages/JobTrackerPage.tsx
@@ -264,9 +264,8 @@ export default function JobTrackerPage({ jobs, onAddJob, onUpdateJob }: JobTrack
                     <div
                       key={job.id}
                       onClick={() => setSelectedJob(job)}
-                      className={`rounded-xl bg-card border p-3 cursor-pointer hover:border-primary/30 transition-all ${
-                        isOverdue(job) ? "border-destructive/50 shadow-[0_0_10px_-3px_hsl(var(--destructive)/0.4)]" : "border-border"
-                      }`}
+                      className={`rounded-xl bg-card border p-3 cursor-pointer hover:border-primary/30 transition-all ${isOverdue(job) ? "border-destructive/50 shadow-[0_0_10px_-3px_hsl(var(--destructive)/0.4)]" : "border-border"
+                        }`}
                     >
                       <div className="flex items-center gap-2 mb-1">
                         <div className="w-8 h-8 rounded-lg bg-secondary flex items-center justify-center text-xs font-bold text-muted-foreground">
@@ -323,7 +322,9 @@ export default function JobTrackerPage({ jobs, onAddJob, onUpdateJob }: JobTrack
                             void updateSelectedJobStatus(job, v as Status);
                           }}
                         >
-                          <SelectTrigger className="w-[130px] h-8 bg-secondary/50 text-xs">
+                          <SelectTrigger
+                            className={`w-[130px] h-8 text-xs border ${statusColor[job.status]}`}
+                          >
                             <SelectValue />
                           </SelectTrigger>
                           <SelectContent>


### PR DESCRIPTION
## Summary

Closes #56 

- What problem does this PR solve?
    - In the card view in job tracker page the status are shown in different colors but in the list view it is not the case. This creates inconsistency. 
- What changed?
    - The status chips in the list view also now has color coded status.  

## Validation

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [ ] `python -m compileall backend` (NO BACKEND CHANGED)

## Screenshots

Before 
<img width="1558" height="696" alt="image" src="https://github.com/user-attachments/assets/53a45c8d-0f01-4e50-a47f-3f9bf39912da" />


After

<img width="1597" height="686" alt="image" src="https://github.com/user-attachments/assets/2a9a030e-47c5-499e-aab0-fc6ef3ad6034" />


## Risks

NA

##Additional Info

AI Usage: Ai used to write commit messgae. 

Kindly please add the appropriate gssoc:approved , quality , level and type labels so it can be tracked. Thanks!
