### PR TITLE
fix(dashboard): correct Avg Mock Score scaling

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -27,7 +27,7 @@ export default function DashboardPage({ user, profile, sessions, mocks, jobs }: 
 
   const completionPercent = profile?.onboardingComplete ? 100 : 0;
   const avgScore = mocks.length
-    ? Math.round(mocks.reduce((s, m) => s + m.aiScore, 0) / mocks.length)
+    ? Math.round(mocks.reduce((s, m) => s + m.aiScore * 10, 0) / mocks.length)
     : 0;
 
   const recentSessions = sessions.slice(-3).reverse();


### PR DESCRIPTION
## Description

Fixed the Dashboard Avg Mock Score scaling inconsistency.

Previously, the dashboard displayed raw `aiScore` values (1–10 scale) directly against a `/100` label, causing values like `7/100` instead of the intended `70/100`.

### Changes made

* Scaled `aiScore` values by 10 during average calculation
* Kept logic consistent with `ProgressPage`
* Preserved mathematical precision before rounding
* Maintained existing UI and component behavior

### Testing

* Verified dashboard score displays correctly
* Confirmed ProgressPage consistency
* Ran production build successfully
* Passed lint checks with 0 errors
* Verified tests pass successfully

Fixes #76