### PR TITLE
feat: Link Job Applications to Prep Sessions in Job Tracker Details

### DIFF
--- a/src/pages/JobTrackerPage.tsx
+++ b/src/pages/JobTrackerPage.tsx
@@ -31,7 +31,7 @@ interface JobTrackerPageProps {
   userId: string;
 }
 
-export default function JobTrackerPage({ jobs, onAddJob, onUpdateJob }: JobTrackerPageProps) {
+export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob }: JobTrackerPageProps) {
   const [view, setView] = useState<"kanban" | "table">("kanban");
   const [showAdd, setShowAdd] = useState(false);
   const [selectedJob, setSelectedJob] = useState<JobApplication | null>(null);
@@ -231,6 +231,25 @@ export default function JobTrackerPage({ jobs, onAddJob, onUpdateJob }: JobTrack
               <div>
                 <Label>Next Action Date</Label>
                 <Input type="date" value={draftJob.nextActionDate} onChange={(e) => setDraftJob({ ...draftJob, nextActionDate: e.target.value })} className="mt-1 bg-secondary/50" />
+              </div>
+              <div>
+                <Label>Linked Prep Session</Label>
+                <Select
+                  value={draftJob.linkedPrepSessionId || "none"}
+                  onValueChange={(v) => setDraftJob({ ...draftJob, linkedPrepSessionId: v === "none" ? null : v })}
+                >
+                  <SelectTrigger className="mt-1 bg-secondary/50">
+                    <SelectValue placeholder="Select a prep session" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">None / No Prep Session</SelectItem>
+                    {sessions?.map((s) => (
+                      <SelectItem key={s.id} value={s.id}>
+                        {s.company} — {s.jobTitle}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
               <div>
                 <Label>Notes</Label>


### PR DESCRIPTION
Fixes missing 'sessions' prop destructuring and adds a 'Linked Prep Session' dropdown selector to the Job Details Sheet, enabling the user to natively link their job applications to their interview prep sessions.

Scope completed as requested:
- [x] Fix the sessions destructuring in component props
- [x] Add the linked prep session dropdown in the job details Sheet
- [x] No backend changes needed

Closes #80