### PR TITLE
fix(dashboard): scale avg mock score before /100 display (#76)

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -83,7 +83,7 @@ export default function DashboardPage({ user, profile, sessions, mocks, jobs }: 
         <StatCard icon={BookOpen} label="Prep Sessions" value={sessions.length} />
         <StatCard icon={MessageSquare} label="Mock Interviews" value={mocks.length} gradient="gradient-accent" />
         <StatCard icon={Briefcase} label="Jobs Applied" value={jobs.length} gradient="gradient-warm" />
-        <StatCard icon={TrendingUp} label="Avg Mock Score" value={`${avgScore}/100`} gradient="gradient-success" />
+        <StatCard icon={TrendingUp} label="Avg Mock Score" value={`${avgScore * 10}/100`} gradient="gradient-success" />
       </div>
 
       {/* Quick Actions */}


### PR DESCRIPTION
## Summary

Fixes #76 — Avg Mock Score on the Dashboard was showing the raw 1–10 value
against a /100 label (e.g., 7/100). Now it scales the display by 10 so
it shows 70/100.

## Validation

- [ ] `npm run build`
- [ ] `npx tsc --noEmit`
- [ ] `python -m compileall backend`

## Risks

Low — UI-only display change; no API, data, or deployment impact.