### PR TITLE
Fix job status select bubbling

### DIFF
--- a/src/pages/JobTrackerPage.tsx
+++ b/src/pages/JobTrackerPage.tsx
@@ -503,7 +503,7 @@ export default function JobTrackerPage({ jobs, onAddJob, onUpdateJob }: JobTrack
                       <td className="py-3 px-4 font-medium text-foreground">{job.companyName}</td>
                       <td className="py-3 px-4 text-muted-foreground">{job.jobTitle}</td>
                       <td className="py-3 px-4 text-muted-foreground">{job.dateApplied}</td>
-                      <td className="py-3 px-4">
+                      <td className="py-3 px-4" onClick={(e) => e.stopPropagation()}>
                         <Select
                           value={job.status}
                           onValueChange={(v) => {


### PR DESCRIPTION
Closes #77 
## Summary

* Fixes a bug in Job Tracker table view where changing the status from the dropdown also opened the detail sheet.
* Added click event isolation on the status cell so Select interactions no longer bubble to the row click handler.

## Validation

* [x] `npm run build`
* [x] `npx tsc --noEmit`
* [x] `python -m compileall backend`

## Screenshots

* Not needed. This is a behavior-only fix with no UI layout changes.

## Risks

* Low risk. The change is scoped to the Job Tracker table view and only affects click propagation on the status cell.
