### PR TITLE
Security: Add authentication to ML endpoints

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,7 +14,7 @@ from urllib.request import Request, urlopen
 from typing import Any, Literal
 from uuid import uuid4
 
-from fastapi import Depends, FastAPI, Header, HTTPException, Query, Response, status
+from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 from sqlalchemy import JSON, Boolean, DateTime, Integer, String, Text, create_engine, delete, func, select
@@ -717,7 +717,7 @@ def evaluate_mock_attempt(question: str, answer: str) -> tuple[int, MockFeedback
 
 
 def require_current_user(
-    user_id: str,
+    user_id: str | None = None,
     authorization: str | None = Header(default=None),
     db: Session = Depends(get_db),
 ) -> UserTable:
@@ -726,13 +726,20 @@ def require_current_user(
 
     payload = decode_token(authorization.removeprefix("Bearer ").strip())
     token_user_id = payload.get("sub")
-    if token_user_id != user_id:
+    if user_id is not None and token_user_id != user_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
 
-    user = db.get(UserTable, user_id)
+    user = db.get(UserTable, token_user_id)
     if not user:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
     return user
+
+
+def validate_payload_size(request: Request) -> None:
+    if "content-length" in request.headers:
+        length = int(request.headers["content-length"])
+        if length > 10240:
+            raise HTTPException(status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, detail="Request entity too large")
 
 
 app = FastAPI(title="PrepIQ Backend", version="2.0.0")
@@ -1121,20 +1128,20 @@ class ConfidenceRequest(BaseModel):
     text: str
 
 
-@app.post("/api/ml/extract-skills", response_model=ExtractSkillsResponse)
+@app.post("/api/ml/extract-skills", response_model=ExtractSkillsResponse, dependencies=[Depends(require_current_user), Depends(validate_payload_size)])
 def ml_extract_skills(payload: ExtractSkillsRequest) -> ExtractSkillsResponse:
     skills = extract_skills(payload.text)
     return ExtractSkillsResponse(skills=skills, count=len(skills))
 
 
-@app.post("/api/ml/match-score", response_model=MatchScoreResponse)
+@app.post("/api/ml/match-score", response_model=MatchScoreResponse, dependencies=[Depends(require_current_user), Depends(validate_payload_size)])
 def ml_match_score(payload: MatchScoreRequest) -> MatchScoreResponse:
     score = compute_match_score(payload.resumeText, payload.jdText)
     label = "Strong match" if score >= 70 else "Moderate match" if score >= 50 else "Weak match"
     return MatchScoreResponse(score=score, label=label)
 
 
-@app.post("/api/ml/analyze-confidence", response_model=ConfidenceAnalysis)
+@app.post("/api/ml/analyze-confidence", response_model=ConfidenceAnalysis, dependencies=[Depends(require_current_user), Depends(validate_payload_size)])
 def ml_analyze_confidence(payload: ConfidenceRequest) -> ConfidenceAnalysis:
     result = analyze_confidence(payload.text)
     return ConfidenceAnalysis(**result)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -85,8 +85,10 @@ class PrepIQApiTestCase(unittest.TestCase):
         from backend.app import ml
 
         ml._spacy_nlp = False
+        _, headers = self.create_account()
         response = self.client.post(
             "/api/ml/extract-skills",
+            headers=headers,
             json={"text": "Built Python and React applications with PostgreSQL."},
         )
 
@@ -100,9 +102,11 @@ class PrepIQApiTestCase(unittest.TestCase):
         from backend.app import ml
 
         ml._spacy_nlp = False
+        _, headers = self.create_account()
 
         response = self.client.post(
             "/api/ml/extract-skills",
+            headers=headers,
             json={
                 "text": """
                 Worked on machine-learning, spring_boot,
@@ -125,8 +129,10 @@ class PrepIQApiTestCase(unittest.TestCase):
         self.assertIn("JWT", skills)
 
     def test_match_score_endpoint_returns_score_and_label(self) -> None:
+        _, headers = self.create_account()
         response = self.client.post(
             "/api/ml/match-score",
+            headers=headers,
             json={
                 "resumeText": "Python developer with FastAPI, SQL, and machine learning experience.",
                 "jdText": "Looking for a Python engineer with FastAPI and SQL skills.",
@@ -141,8 +147,10 @@ class PrepIQApiTestCase(unittest.TestCase):
         self.assertIn(payload["label"], {"Strong match", "Moderate match", "Weak match"})
 
     def test_analyze_confidence_endpoint_returns_analysis_shape(self) -> None:
+        _, headers = self.create_account()
         response = self.client.post(
             "/api/ml/analyze-confidence",
+            headers=headers,
             json={
                 "text": "I led a team of 4 engineers and improved deployment speed by 30 percent.",
             },
@@ -155,6 +163,23 @@ class PrepIQApiTestCase(unittest.TestCase):
         self.assertIsInstance(payload["wordCount"], int)
         self.assertIn(payload["sentiment"], {"positive", "neutral", "negative"})
         self.assertGreater(payload["wordCount"], 0)
+
+    def test_ml_endpoints_require_auth(self) -> None:
+        response = self.client.post(
+            "/api/ml/extract-skills",
+            json={"text": "test"},
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_ml_endpoints_payload_size_limit(self) -> None:
+        _, headers = self.create_account()
+        large_text = "a" * 11000
+        response = self.client.post(
+            "/api/ml/extract-skills",
+            headers=headers,
+            json={"text": large_text},
+        )
+        self.assertEqual(response.status_code, 413)
 
     def test_signup_login_and_me(self) -> None:
         email = f"login-{uuid4().hex[:8]}@example.com"


### PR DESCRIPTION
Closes #87

## Summary

**What problem does this PR solve?**
The three ML endpoints (`/api/ml/extract-skills`, `/api/ml/match-score`, `/api/ml/analyze-confidence`) were publicly accessible without any authentication. This exposed them to potential abuse where anyone could consume expensive server resources (like spaCy NER and TF-IDF computation) for free. 

**What changed?**
- Modified the existing `require_current_user` dependency in `backend/app/main.py` to make the `user_id` optional. This allows us to cleanly reuse the dependency for the ML routes (which don't have a `{user_id}` path parameter) while maintaining existing functionality for user profile routes.
- Added a new `validate_payload_size` dependency that rejects incoming requests containing a payload exceeding 10KB with a `413 Request Entity Too Large` error.
- Hooked both dependencies into the three ML endpoints.
- Updated `backend/tests/test_api.py` to ensure all existing ML endpoint tests now use valid authentication tokens.
- Added new test cases in `backend/tests/test_api.py` to verify that unauthenticated requests return `401` and oversized payloads correctly return `413`.

## Validation

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `python -m compileall backend`

*(Note: The backend tests were also successfully executed via `pytest` and all 13 tests passed!)*

## Screenshots

N/A — This is a backend API security update. No UI changes were made.

## Risks

**API Concerns:**
The API behavior for the ML endpoints (`/api/ml/extract-skills`, `/api/ml/match-score`, `/api/ml/analyze-confidence`) has changed. They now strictly require a valid JWT Bearer token in the `Authorization` header and will reject payloads larger than 10KB. Any external clients that were hitting these endpoints directly without authentication will now receive a `401 Unauthorized`. 

**Deployment Concerns:**
None. Internal app flows generating prep sessions seamlessly pass the authentication and remain fully functional. No database migrations are required.
