### PR TITLE
feat: add PDF and DOCX upload support for interview prep

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1209,7 +1209,6 @@ def get_sessions(
 
 @app.get("/api/users/{user_id}/sessions/{session_id}", response_model=InterviewSession)
 def get_session(
-
     user_id: str,
     session_id: str,
     _: UserTable = Depends(require_current_user),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import hashlib
 import hmac
+import io
 import json
 import logging
 import os
@@ -17,11 +18,13 @@ import httpx
 from fastapi import (
     Depends,
     FastAPI,
+    File,
     Header,
     HTTPException,
     Query,
     Request,
     Response,
+    UploadFile,
     status,
 )
 from fastapi.middleware.cors import CORSMiddleware
@@ -1562,3 +1565,89 @@ def ml_match_score(payload: MatchScoreRequest) -> MatchScoreResponse:
 def ml_analyze_confidence(payload: ConfidenceRequest) -> ConfidenceAnalysis:
     result = analyze_confidence(payload.text)
     return ConfidenceAnalysis(**result)
+
+
+# ---------------------------------------------------------------------------
+# Document text extraction endpoint (Issue #93)
+# ---------------------------------------------------------------------------
+
+ALLOWED_EXTENSIONS = {".pdf", ".docx"}
+ALLOWED_MIME_TYPES = {
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+}
+MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024  # 5 MB
+
+
+class ExtractDocumentTextResponse(BaseModel):
+    text: str
+    filename: str
+    pages: int
+
+
+@app.post("/api/extract-document-text", response_model=ExtractDocumentTextResponse)
+async def extract_document_text(file: UploadFile = File(...)) -> ExtractDocumentTextResponse:
+    """Extract text from an uploaded PDF or DOCX file (in-memory only)."""
+
+    filename = file.filename or "unknown"
+    ext = os.path.splitext(filename)[1].lower()
+
+    # Validate file extension
+    if ext not in ALLOWED_EXTENSIONS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unsupported file type '{ext}'. Only .pdf and .docx files are accepted.",
+        )
+
+    # Validate MIME type
+    content_type = (file.content_type or "").lower()
+    if content_type not in ALLOWED_MIME_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid MIME type '{content_type}'. Expected PDF or DOCX.",
+        )
+
+    # Read file into memory and validate size
+    file_bytes = await file.read()
+    if len(file_bytes) > MAX_FILE_SIZE_BYTES:
+        size_mb = len(file_bytes) / (1024 * 1024)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"File too large ({size_mb:.1f} MB). Maximum allowed size is 5 MB.",
+        )
+
+    try:
+        if ext == ".pdf":
+            import pdfplumber
+
+            pages_text: list[str] = []
+            with pdfplumber.open(io.BytesIO(file_bytes)) as pdf:
+                page_count = len(pdf.pages)
+                for page in pdf.pages:
+                    text = page.extract_text()
+                    if text:
+                        pages_text.append(text)
+            extracted = "\n\n".join(pages_text)
+
+        else:  # .docx
+            from docx import Document
+
+            doc = Document(io.BytesIO(file_bytes))
+            paragraphs = [p.text for p in doc.paragraphs if p.text.strip()]
+            extracted = "\n".join(paragraphs)
+            page_count = max(1, len(paragraphs) // 25)  # Approximate page count
+
+    except Exception as exc:
+        logger.warning("Document extraction failed for '%s': %s", filename, exc)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Failed to extract text from '{filename}'. The file may be corrupted or password-protected.",
+        ) from exc
+
+    if not extracted.strip():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"No text content found in '{filename}'. The file may contain only images or be empty.",
+        )
+
+    return ExtractDocumentTextResponse(text=extracted.strip(), filename=filename, pages=page_count)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1209,6 +1209,7 @@ def get_sessions(
 
 @app.get("/api/users/{user_id}/sessions/{session_id}", response_model=InterviewSession)
 def get_session(
+
     user_id: str,
     session_id: str,
     _: UserTable = Depends(require_current_user),
@@ -1610,14 +1611,28 @@ async def extract_document_text(
             detail=f"Invalid MIME type '{content_type}'. Expected PDF or DOCX.",
         )
 
-    # Read file into memory and validate size
-    file_bytes = await file.read()
-    if len(file_bytes) > MAX_FILE_SIZE_BYTES:
-        size_mb = len(file_bytes) / (1024 * 1024)
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"File too large ({size_mb:.1f} MB). Maximum allowed size is 5 MB.",
-        )
+    # Read file into memory and validate size in a safe chunked manner
+    MAX_FILE_SIZE = 5 * 1024 * 1024
+
+    content = bytearray()
+    size = 0
+
+    try:
+        while chunk := await file.read(1024 * 1024):
+            size += len(chunk)
+
+            if size > MAX_FILE_SIZE:
+                raise HTTPException(
+                    status_code=400,
+                    detail="File size exceeds 5MB limit",
+                )
+
+            content.extend(chunk)
+
+        file_bytes = bytes(content)
+
+    finally:
+        await file.close()
 
     try:
         if ext == ".pdf":
@@ -1653,4 +1668,6 @@ async def extract_document_text(
             detail=f"No text content found in '{filename}'. The file may contain only images or be empty.",
         )
 
-    return ExtractDocumentTextResponse(text=extracted.strip(), filename=filename, pages=page_count)
+    return ExtractDocumentTextResponse(
+        text=extracted.strip(), filename=filename, pages=page_count
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1586,7 +1586,10 @@ class ExtractDocumentTextResponse(BaseModel):
 
 
 @app.post("/api/extract-document-text", response_model=ExtractDocumentTextResponse)
-async def extract_document_text(file: UploadFile = File(...)) -> ExtractDocumentTextResponse:
+async def extract_document_text(
+    file: UploadFile = File(...),
+    _: UserTable = Depends(require_current_user),
+) -> ExtractDocumentTextResponse:
     """Extract text from an uploaded PDF or DOCX file (in-memory only)."""
 
     filename = file.filename or "unknown"

--- a/backend/app/ml.py
+++ b/backend/app/ml.py
@@ -29,10 +29,13 @@ def _get_spacy():
     if _spacy_nlp is None:
         try:
             import spacy
+
             _spacy_nlp = spacy.load("en_core_web_sm")
             logger.info("spaCy model loaded successfully")
         except OSError:
-            logger.warning("spaCy model 'en_core_web_sm' not found. Run: python -m spacy download en_core_web_sm")
+            logger.warning(
+                "spaCy model 'en_core_web_sm' not found. Run: python -m spacy download en_core_web_sm"
+            )
             _spacy_nlp = False  # Mark as failed so we don't retry
     return _spacy_nlp if _spacy_nlp is not False else None
 
@@ -43,49 +46,162 @@ def _get_spacy():
 
 TECH_SKILLS = {
     # Programming Languages
-    "python", "javascript", "typescript", "java", "c++", "c#", "go", "golang",
-    "rust", "ruby", "php", "swift", "kotlin", "scala", "r", "matlab", "perl",
-    "dart", "lua", "haskell", "elixir", "clojure",
-
+    "python",
+    "javascript",
+    "typescript",
+    "java",
+    "c++",
+    "c#",
+    "go",
+    "golang",
+    "rust",
+    "ruby",
+    "php",
+    "swift",
+    "kotlin",
+    "scala",
+    "r",
+    "matlab",
+    "perl",
+    "dart",
+    "lua",
+    "haskell",
+    "elixir",
+    "clojure",
     # Frontend
-    "react", "reactjs", "react.js", "angular", "vue", "vuejs", "vue.js",
-    "next.js", "nextjs", "nuxt", "svelte", "html", "css", "sass", "scss",
-    "tailwind", "tailwindcss", "bootstrap", "jquery", "webpack", "vite",
-    "redux", "zustand", "framer motion",
-
+    "react",
+    "reactjs",
+    "react.js",
+    "angular",
+    "vue",
+    "vuejs",
+    "vue.js",
+    "next.js",
+    "nextjs",
+    "nuxt",
+    "svelte",
+    "html",
+    "css",
+    "sass",
+    "scss",
+    "tailwind",
+    "tailwindcss",
+    "bootstrap",
+    "jquery",
+    "webpack",
+    "vite",
+    "redux",
+    "zustand",
+    "framer motion",
     # Backend
-    "node", "nodejs", "node.js", "express", "expressjs", "fastapi", "flask",
-    "django", "spring", "spring boot", "laravel", "rails", "ruby on rails",
-    "asp.net", "gin", "fiber", "nestjs",
-
+    "node",
+    "nodejs",
+    "node.js",
+    "express",
+    "expressjs",
+    "fastapi",
+    "flask",
+    "django",
+    "spring",
+    "spring boot",
+    "laravel",
+    "rails",
+    "ruby on rails",
+    "asp.net",
+    "gin",
+    "fiber",
+    "nestjs",
     # Databases
-    "sql", "mysql", "postgresql", "postgres", "mongodb", "redis", "sqlite",
-    "dynamodb", "cassandra", "elasticsearch", "neo4j", "firebase", "supabase",
-    "prisma", "sequelize", "sqlalchemy", "mongoose",
-
+    "sql",
+    "mysql",
+    "postgresql",
+    "postgres",
+    "mongodb",
+    "redis",
+    "sqlite",
+    "dynamodb",
+    "cassandra",
+    "elasticsearch",
+    "neo4j",
+    "firebase",
+    "supabase",
+    "prisma",
+    "sequelize",
+    "sqlalchemy",
+    "mongoose",
     # Cloud & DevOps
-    "aws", "azure", "gcp", "google cloud", "docker", "kubernetes", "k8s",
-    "terraform", "ansible", "jenkins", "ci/cd", "github actions", "gitlab ci",
-    "nginx", "apache", "linux", "bash", "shell scripting",
-
+    "aws",
+    "azure",
+    "gcp",
+    "google cloud",
+    "docker",
+    "kubernetes",
+    "k8s",
+    "terraform",
+    "ansible",
+    "jenkins",
+    "ci/cd",
+    "github actions",
+    "gitlab ci",
+    "nginx",
+    "apache",
+    "linux",
+    "bash",
+    "shell scripting",
     # AI/ML
-    "machine learning", "deep learning", "tensorflow", "pytorch", "keras",
-    "scikit-learn", "sklearn", "pandas", "numpy", "opencv", "nlp",
-    "natural language processing", "computer vision", "transformers",
-    "hugging face", "langchain", "openai", "llm",
-
+    "machine learning",
+    "deep learning",
+    "tensorflow",
+    "pytorch",
+    "keras",
+    "scikit-learn",
+    "sklearn",
+    "pandas",
+    "numpy",
+    "opencv",
+    "nlp",
+    "natural language processing",
+    "computer vision",
+    "transformers",
+    "hugging face",
+    "langchain",
+    "openai",
+    "llm",
     # Tools & Misc
-    "git", "github", "gitlab", "bitbucket", "jira", "confluence",
-    "figma", "postman", "swagger", "graphql", "rest", "restful",
-    "api", "microservices", "agile", "scrum", "kanban",
-    "testing", "jest", "pytest", "unittest", "cypress", "selenium",
-    "oauth", "jwt", "websockets", "grpc",
+    "git",
+    "github",
+    "gitlab",
+    "bitbucket",
+    "jira",
+    "confluence",
+    "figma",
+    "postman",
+    "swagger",
+    "graphql",
+    "rest",
+    "restful",
+    "api",
+    "microservices",
+    "agile",
+    "scrum",
+    "kanban",
+    "testing",
+    "jest",
+    "pytest",
+    "unittest",
+    "cypress",
+    "selenium",
+    "oauth",
+    "jwt",
+    "websockets",
+    "grpc",
 }
 
 
 # ---------------------------------------------------------------------------
 # Feature 1: Resume Skill Extraction
 # ---------------------------------------------------------------------------
+
 
 def extract_skills(text: str) -> list[str]:
     """
@@ -99,27 +215,23 @@ def extract_skills(text: str) -> list[str]:
     found_skills: set[str] = set()
     text_lower = text.lower()
     # Normalize separators and spacing for multi-word skill matching
-    normalized_text = re.sub(r'[-_/]', ' ', text_lower)
-    normalized_text = re.sub(r'\s+', ' ', normalized_text).strip()
-
+    normalized_text = re.sub(r"[-_/]", " ", text_lower)
+    normalized_text = re.sub(r"\s+", " ", normalized_text).strip()
 
     # Method 1: Keyword matching against curated skill list
     for skill in sorted(TECH_SKILLS, key=len, reverse=True):
         # Multi-word skills need safer boundary handling
-        if ' ' in skill:
-            pattern = r'(?<!\w)' + re.escape(skill) + r'(?!\w)'
+        if " " in skill:
+            pattern = r"(?<!\w)" + re.escape(skill) + r"(?!\w)"
         else:
-            pattern = r'\b' + re.escape(skill) + r'\b'
+            pattern = r"\b" + re.escape(skill) + r"\b"
 
         if re.search(pattern, normalized_text):
-
             # Avoid adding shorter overlapping skills
             if any(skill in existing.lower() for existing in found_skills):
                 continue
 
-            found_skills.add(
-                skill.title() if len(skill) > 3 else skill.upper()
-            )
+            found_skills.add(skill.title() if len(skill) > 3 else skill.upper())
 
     # Method 2: spaCy NER to catch additional entities
     nlp = _get_spacy()
@@ -142,6 +254,7 @@ def extract_skills(text: str) -> list[str]:
 # ---------------------------------------------------------------------------
 # Feature 2: Resume ↔ JD Match Score
 # ---------------------------------------------------------------------------
+
 
 def compute_match_score(resume_text: str, jd_text: str) -> int:
     """
@@ -182,6 +295,7 @@ def compute_match_score(resume_text: str, jd_text: str) -> int:
 # Feature 3: Answer Confidence Analysis
 # ---------------------------------------------------------------------------
 
+
 def analyze_confidence(answer_text: str) -> dict[str, Any]:
     """
     Analyze the confidence and quality of a mock interview answer
@@ -203,7 +317,7 @@ def analyze_confidence(answer_text: str) -> dict[str, Any]:
 
     words = answer_text.split()
     word_count = len(words)
-    sentences = [s.strip() for s in re.split(r'[.!?]+', answer_text) if s.strip()]
+    sentences = [s.strip() for s in re.split(r"[.!?]+", answer_text) if s.strip()]
     sentence_count = max(1, len(sentences))
 
     # --- Sentiment analysis with TextBlob ---
@@ -211,8 +325,9 @@ def analyze_confidence(answer_text: str) -> dict[str, Any]:
 
     try:
         from textblob import TextBlob
+
         blob = TextBlob(answer_text)
-        polarity = blob.sentiment.polarity        # -1.0 to 1.0
+        polarity = blob.sentiment.polarity  # -1.0 to 1.0
 
     except Exception as exc:
         logger.warning("TextBlob sentiment analysis failed: %s", exc)
@@ -227,10 +342,25 @@ def analyze_confidence(answer_text: str) -> dict[str, Any]:
 
     # --- Specificity score ---
     # More numbers, percentages, and concrete metrics = more specific
-    number_count = len(re.findall(r'\b\d+[\d,.]*%?\b', answer_text))
-    metric_keywords = ["increased", "decreased", "improved", "reduced", "achieved",
-                       "delivered", "built", "managed", "led", "saved", "generated",
-                       "revenue", "users", "clients", "team", "project"]
+    number_count = len(re.findall(r"\b\d+[\d,.]*%?\b", answer_text))
+    metric_keywords = [
+        "increased",
+        "decreased",
+        "improved",
+        "reduced",
+        "achieved",
+        "delivered",
+        "built",
+        "managed",
+        "led",
+        "saved",
+        "generated",
+        "revenue",
+        "users",
+        "clients",
+        "team",
+        "project",
+    ]
     metric_hits = sum(1 for kw in metric_keywords if kw in answer_text.lower())
 
     specificity_raw = (number_count * 15) + (metric_hits * 8)
@@ -238,12 +368,14 @@ def analyze_confidence(answer_text: str) -> dict[str, Any]:
 
     # --- Confidence score ---
     # Composite of: sentiment, length, specificity, sentence structure
-    length_score = min(40, word_count * 0.2)           # Up to 40 pts for length (200+ words)
-    sentiment_score = max(0, (polarity + 1) * 15)      # Up to 30 pts for positive tone
-    specificity_score = specificity * 0.2               # Up to 20 pts for specifics
-    structure_score = min(10, sentence_count * 2)       # Up to 10 pts for multi-sentence
+    length_score = min(40, word_count * 0.2)  # Up to 40 pts for length (200+ words)
+    sentiment_score = max(0, (polarity + 1) * 15)  # Up to 30 pts for positive tone
+    specificity_score = specificity * 0.2  # Up to 20 pts for specifics
+    structure_score = min(10, sentence_count * 2)  # Up to 10 pts for multi-sentence
 
-    confidence_score = int(min(100, length_score + sentiment_score + specificity_score + structure_score))
+    confidence_score = int(
+        min(100, length_score + sentiment_score + specificity_score + structure_score)
+    )
 
     return {
         "confidenceScore": confidence_score,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,6 @@ scikit-learn==1.5.2
 textblob==0.18.0
 httpx
 ruff
+pdfplumber
+python-docx
+python-multipart

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -47,7 +47,9 @@ class PrepIQApiTestCase(unittest.TestCase):
     def test_load_local_env_preserves_existing_environment(self) -> None:
         from backend.app.main import load_local_env
 
-        with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as env_file:
+        with tempfile.NamedTemporaryFile(
+            "w", delete=False, encoding="utf-8"
+        ) as env_file:
             env_file.write("PREPIQ_TEST_ENV=from-file\n")
             env_file.write("PREPIQ_EXISTING_ENV=from-file\n")
             env_path = env_file.name
@@ -142,7 +144,9 @@ class PrepIQApiTestCase(unittest.TestCase):
         self.assertIsInstance(payload["score"], int)
         self.assertGreaterEqual(payload["score"], 0)
         self.assertLessEqual(payload["score"], 100)
-        self.assertIn(payload["label"], {"Strong match", "Moderate match", "Weak match"})
+        self.assertIn(
+            payload["label"], {"Strong match", "Moderate match", "Weak match"}
+        )
 
     def test_analyze_confidence_endpoint_returns_analysis_shape(self) -> None:
         _, headers = self.create_account()
@@ -194,12 +198,16 @@ class PrepIQApiTestCase(unittest.TestCase):
         self.assertEqual(login.status_code, 200, login.text)
         token = login.json()["token"]
 
-        me = self.client.get("/api/auth/me", headers={"Authorization": f"Bearer {token}"})
+        me = self.client.get(
+            "/api/auth/me", headers={"Authorization": f"Bearer {token}"}
+        )
         self.assertEqual(me.status_code, 200, me.text)
         self.assertEqual(me.json()["email"], email)
 
         tampered_token = f"{token[:-1]}{'a' if token[-1] != 'a' else 'b'}"
-        tampered_me = self.client.get("/api/auth/me", headers={"Authorization": f"Bearer {tampered_token}"})
+        tampered_me = self.client.get(
+            "/api/auth/me", headers={"Authorization": f"Bearer {tampered_token}"}
+        )
         self.assertEqual(tampered_me.status_code, 401, tampered_me.text)
 
     def test_login_wrong_password_returns_401(self) -> None:
@@ -224,11 +232,13 @@ class PrepIQApiTestCase(unittest.TestCase):
 
         user_id, _ = self.create_account()
 
-        expired_token = encode_token({
-            "sub": user_id,
-            "email": "expired@example.com",
-            "exp": int((utc_now() - timedelta(hours=1)).timestamp()),
-        })
+        expired_token = encode_token(
+            {
+                "sub": user_id,
+                "email": "expired@example.com",
+                "exp": int((utc_now() - timedelta(hours=1)).timestamp()),
+            }
+        )
 
         response = self.client.get(
             f"/api/users/{user_id}/sessions",
@@ -337,12 +347,18 @@ class PrepIQApiTestCase(unittest.TestCase):
         patch = self.client.patch(
             f"/api/users/{user_id}/jobs/{job_id}",
             headers=headers,
-            json={"status": "Interview", "location": "Remote", "notes": "Follow up next week"},
+            json={
+                "status": "Interview",
+                "location": "Remote",
+                "notes": "Follow up next week",
+            },
         )
         self.assertEqual(patch.status_code, 200, patch.text)
         self.assertEqual(patch.json()["status"], "Interview")
 
-        delete_job = self.client.delete(f"/api/users/{user_id}/jobs/{job_id}", headers=headers)
+        delete_job = self.client.delete(
+            f"/api/users/{user_id}/jobs/{job_id}", headers=headers
+        )
         self.assertEqual(delete_job.status_code, 204, delete_job.text)
 
         jobs = self.client.get(f"/api/users/{user_id}/jobs", headers=headers)
@@ -359,7 +375,9 @@ class PrepIQApiTestCase(unittest.TestCase):
         self.assertEqual(sessions.status_code, 200, sessions.text)
         self.assertEqual(sessions.json(), [])
 
-        mocks_after_delete = self.client.get(f"/api/users/{user_id}/mocks", headers=headers)
+        mocks_after_delete = self.client.get(
+            f"/api/users/{user_id}/mocks", headers=headers
+        )
         self.assertEqual(mocks_after_delete.status_code, 200, mocks_after_delete.text)
         self.assertEqual(mocks_after_delete.json()["items"], [])
         self.assertEqual(mocks_after_delete.json()["total"], 0)

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -64,3 +64,25 @@ export async function apiRequest<T>(path: string, init?: RequestInit): Promise<T
 
   return response.json() as Promise<T>;
 }
+
+/** Upload a file via FormData — does NOT set Content-Type so the browser adds the multipart boundary. */
+export async function apiUpload<T>(path: string, formData: FormData): Promise<T> {
+  const token = getAuthToken();
+  const headers: Record<string, string> = {};
+
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method: "POST",
+    headers,
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw new Error(await parseError(response));
+  }
+
+  return response.json() as Promise<T>;
+}

--- a/src/pages/InterviewPrepPage.tsx
+++ b/src/pages/InterviewPrepPage.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { motion } from "framer-motion";
-import { BookOpen, Loader2, Search, Brain, Cpu } from "lucide-react";
+import { BookOpen, Loader2, Search, Brain, Cpu, Upload } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -9,6 +9,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { useToast } from "@/hooks/use-toast";
+import { apiUpload } from "@/lib/api";
 import {
   CreateInterviewSessionInput,
   InterviewSession,
@@ -21,6 +22,8 @@ interface InterviewPrepPageProps {
   onAddSession: (input: CreateInterviewSessionInput) => Promise<InterviewSession>;
   userId: string;
 }
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
 
 export default function InterviewPrepPage({
   sessions,
@@ -37,6 +40,10 @@ export default function InterviewPrepPage({
   const [typeFilter, setTypeFilter] = useState<string>("all");
   const [diffFilter, setDiffFilter] = useState<string>("all");
   const [selectedJobId, setSelectedJobId] = useState("");
+  const [uploadingJd, setUploadingJd] = useState(false);
+  const [uploadingResume, setUploadingResume] = useState(false);
+  const jdFileRef = useRef<HTMLInputElement>(null);
+  const resumeFileRef = useRef<HTMLInputElement>(null);
   const { toast } = useToast();
 
   const handleImportJob = (jobId: string) => {
@@ -49,6 +56,54 @@ export default function InterviewPrepPage({
     setJobTitle(selectedJob.jobTitle);
     setCompany(selectedJob.companyName);
     setJd(selectedJob.notes || "");
+  };
+
+  const handleFileUpload = async (
+    file: File,
+    setFieldValue: (value: string) => void,
+    setUploading: (value: boolean) => void,
+  ) => {
+    if (file.size > MAX_FILE_SIZE) {
+      toast({
+        title: "File too large",
+        description: `"${file.name}" is ${(file.size / (1024 * 1024)).toFixed(1)} MB. Maximum allowed size is 5 MB.`,
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const ext = file.name.split(".").pop()?.toLowerCase();
+    if (ext !== "pdf" && ext !== "docx") {
+      toast({
+        title: "Unsupported file type",
+        description: "Only .pdf and .docx files are accepted.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      const result = await apiUpload<{ text: string; filename: string; pages: number }>(
+        "/api/extract-document-text",
+        formData,
+      );
+      setFieldValue(result.text);
+      toast({
+        title: "Text extracted successfully",
+        description: `Extracted from "${result.filename}" (${result.pages} page${result.pages !== 1 ? "s" : ""}).`,
+      });
+    } catch (error) {
+      toast({
+        title: "Extraction failed",
+        description: error instanceof Error ? error.message : "Could not extract text from the file.",
+        variant: "destructive",
+      });
+    } finally {
+      setUploading(false);
+    }
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -133,12 +188,72 @@ export default function InterviewPrepPage({
               </div>
             </div>
             <div>
-              <Label>Job Description</Label>
-              <Textarea value={jd} onChange={(e) => setJd(e.target.value)} rows={4} className="mt-1 bg-secondary/50" placeholder="Paste the job description..." />
+              <div className="flex items-center justify-between mb-1">
+                <Label>Job Description</Label>
+                <div>
+                  <input
+                    ref={jdFileRef}
+                    type="file"
+                    accept=".pdf,.docx"
+                    className="hidden"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (file) handleFileUpload(file, setJd, setUploadingJd);
+                      e.target.value = "";
+                    }}
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={uploadingJd}
+                    onClick={() => jdFileRef.current?.click()}
+                    className="h-7 text-xs gap-1.5"
+                  >
+                    {uploadingJd ? (
+                      <Loader2 className="w-3 h-3 animate-spin" />
+                    ) : (
+                      <Upload className="w-3 h-3" />
+                    )}
+                    {uploadingJd ? "Extracting..." : "Upload PDF/DOCX"}
+                  </Button>
+                </div>
+              </div>
+              <Textarea value={jd} onChange={(e) => setJd(e.target.value)} rows={4} className="bg-secondary/50" placeholder="Paste the job description or upload a file..." />
             </div>
             <div>
-              <Label>Your Resume</Label>
-              <Textarea value={resume} onChange={(e) => setResume(e.target.value)} rows={4} className="mt-1 bg-secondary/50" placeholder="Paste your resume content..." />
+              <div className="flex items-center justify-between mb-1">
+                <Label>Your Resume</Label>
+                <div>
+                  <input
+                    ref={resumeFileRef}
+                    type="file"
+                    accept=".pdf,.docx"
+                    className="hidden"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (file) handleFileUpload(file, setResume, setUploadingResume);
+                      e.target.value = "";
+                    }}
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={uploadingResume}
+                    onClick={() => resumeFileRef.current?.click()}
+                    className="h-7 text-xs gap-1.5"
+                  >
+                    {uploadingResume ? (
+                      <Loader2 className="w-3 h-3 animate-spin" />
+                    ) : (
+                      <Upload className="w-3 h-3" />
+                    )}
+                    {uploadingResume ? "Extracting..." : "Upload PDF/DOCX"}
+                  </Button>
+                </div>
+              </div>
+              <Textarea value={resume} onChange={(e) => setResume(e.target.value)} rows={4} className="bg-secondary/50" placeholder="Paste your resume content or upload a file..." />
             </div>
             <div className="flex gap-3">
               <Button type="submit" disabled={loading} className="gradient-primary text-primary-foreground">


### PR DESCRIPTION
## Summary

This PR adds PDF and DOCX upload support for the Interview Prep feature.

Previously, users had to manually copy-paste resume and job description content into textareas, which was time-consuming and error-prone. This implementation allows users to upload `.pdf` and `.docx` files directly and automatically extracts text into the existing form fields while preserving the manual input workflow.

### What changed

* Added PDF/DOCX upload support for Resume and Job Description fields
* Added secure backend text extraction endpoint using FastAPI
* Implemented in-memory file processing (no permanent storage)
* Added extraction support using:

  * `pdfplumber`
  * `python-docx`
  * `python-multipart`
* Added frontend upload buttons and loading states
* Added client-side + server-side validation
* Added file size limit handling (5MB)
* Added extraction error handling for unsupported/corrupted files
* Preserved existing manual textarea workflow

## Validation

* [x] `npm run build`
* [x] `npx tsc --noEmit`
* [x] `python -m compileall backend`


## Risks

* No database migrations required
* No existing API behavior modified
* Existing manual text input flow remains fully backward compatible
* Uploaded files are processed temporarily in-memory and are not stored permanently

Closes #93