### PR TITLE
feat: add job tracker import autofill to interview prep

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -112,7 +112,12 @@ function AppRoutes() {
         <Route path="/onboarding" element={!hydrated ? <RouteFallback /> : user ? <OnboardingPage user={user} profile={profile} onSave={saveProfile} /> : <Navigate to="/login" replace />} />
         <Route path="/dashboard" element={<ProtectedRoute hydrated={hydrated} user={user} logout={logout} resourceErrorMessage={resourceErrorMessage}><DashboardPage user={user!} profile={profile} sessions={sessions} mocks={attempts} jobs={jobs} /></ProtectedRoute>} />
         <Route path="/career-dna" element={<ProtectedRoute hydrated={hydrated} user={user} logout={logout} resourceErrorMessage={resourceErrorMessage}><CareerDNAPage user={user!} profile={profile} /></ProtectedRoute>} />
-        <Route path="/interview-prep" element={<ProtectedRoute hydrated={hydrated} user={user} logout={logout} resourceErrorMessage={resourceErrorMessage}><InterviewPrepPage sessions={sessions} onAddSession={addSession} userId={user?.id || ""} /></ProtectedRoute>} />
+        <Route path="/interview-prep" element={<ProtectedRoute hydrated={hydrated} user={user} logout={logout} resourceErrorMessage={resourceErrorMessage}><InterviewPrepPage
+          sessions={sessions}
+          jobs={jobs}
+          onAddSession={addSession}
+          userId={user?.id || ""}
+        /></ProtectedRoute>} />
         <Route path="/mock-interview" element={<ProtectedRoute hydrated={hydrated} user={user} logout={logout} resourceErrorMessage={resourceErrorMessage}><MockInterviewPage sessions={sessions} attempts={attempts} onAddAttempt={addAttempt} userId={user?.id || ""} /></ProtectedRoute>} />
         <Route path="/job-tracker" element={<ProtectedRoute hydrated={hydrated} user={user} logout={logout} resourceErrorMessage={resourceErrorMessage}><JobTrackerPage jobs={jobs} sessions={sessions} onAddJob={addJob} onUpdateJob={updateJob} userId={user?.id || ""} /></ProtectedRoute>} />
         <Route path="/progress" element={<ProtectedRoute hydrated={hydrated} user={user} logout={logout} resourceErrorMessage={resourceErrorMessage}><ProgressPage mocks={attempts} sessions={sessions} /></ProtectedRoute>} />

--- a/src/pages/InterviewPrepPage.tsx
+++ b/src/pages/InterviewPrepPage.tsx
@@ -9,15 +9,24 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { useToast } from "@/hooks/use-toast";
-import { CreateInterviewSessionInput, InterviewSession } from "@/lib/store";
+import {
+  CreateInterviewSessionInput,
+  InterviewSession,
+  JobApplication,
+} from "@/lib/store";
 
 interface InterviewPrepPageProps {
   sessions: InterviewSession[];
+  jobs: JobApplication[];
   onAddSession: (input: CreateInterviewSessionInput) => Promise<InterviewSession>;
   userId: string;
 }
 
-export default function InterviewPrepPage({ sessions, onAddSession }: InterviewPrepPageProps) {
+export default function InterviewPrepPage({
+  sessions,
+  jobs,
+  onAddSession,
+}: InterviewPrepPageProps) {
   const [showForm, setShowForm] = useState(false);
   const [jobTitle, setJobTitle] = useState("");
   const [company, setCompany] = useState("");
@@ -27,7 +36,20 @@ export default function InterviewPrepPage({ sessions, onAddSession }: InterviewP
   const [activeSession, setActiveSession] = useState<InterviewSession | null>(null);
   const [typeFilter, setTypeFilter] = useState<string>("all");
   const [diffFilter, setDiffFilter] = useState<string>("all");
+  const [selectedJobId, setSelectedJobId] = useState("");
   const { toast } = useToast();
+
+  const handleImportJob = (jobId: string) => {
+    setSelectedJobId(jobId);
+
+    const selectedJob = jobs.find((job) => job.id === jobId);
+
+    if (!selectedJob) return;
+
+    setJobTitle(selectedJob.jobTitle);
+    setCompany(selectedJob.companyName);
+    setJd(selectedJob.notes || "");
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -81,6 +103,25 @@ export default function InterviewPrepPage({ sessions, onAddSession }: InterviewP
       {showForm && (
         <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }}>
           <form onSubmit={handleSubmit} className="bg-card border border-border rounded-2xl p-6 shadow-card space-y-4">
+            {jobs.length > 0 && (
+              <div>
+                <Label>Import from Job Tracker</Label>
+
+                <select
+                  value={selectedJobId}
+                  onChange={(e) => handleImportJob(e.target.value)}
+                  className="w-full mt-1 px-3 py-2 rounded-md bg-secondary/50 border border-border text-sm"
+                >
+                  <option value="">Select a job application</option>
+
+                  {jobs.map((job) => (
+                    <option key={job.id} value={job.id}>
+                      {job.companyName} — {job.jobTitle}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
             <div className="grid md:grid-cols-2 gap-4">
               <div>
                 <Label>Job Title</Label>
@@ -232,20 +273,19 @@ export default function InterviewPrepPage({ sessions, onAddSession }: InterviewP
                           background: activeSession.mlMatchScore >= 70
                             ? "hsl(var(--success))"
                             : activeSession.mlMatchScore >= 50
-                            ? "hsl(var(--warning))"
-                            : "hsl(var(--destructive))",
+                              ? "hsl(var(--warning))"
+                              : "hsl(var(--destructive))",
                         }}
                       />
                     </div>
                   </div>
                   <span
-                    className={`text-xs font-semibold px-2.5 py-1 rounded-full border ${
-                      activeSession.mlMatchScore >= 70
-                        ? "bg-success/10 text-success border-success/30"
-                        : activeSession.mlMatchScore >= 50
+                    className={`text-xs font-semibold px-2.5 py-1 rounded-full border ${activeSession.mlMatchScore >= 70
+                      ? "bg-success/10 text-success border-success/30"
+                      : activeSession.mlMatchScore >= 50
                         ? "bg-warning/10 text-warning border-warning/30"
                         : "bg-destructive/10 text-destructive border-destructive/30"
-                    }`}
+                      }`}
                   >
                     {activeSession.mlMatchScore >= 70 ? "Strong" : activeSession.mlMatchScore >= 50 ? "Moderate" : "Weak"}
                   </span>


### PR DESCRIPTION
## Summary

- Added integration between Job Tracker and Interview Prep.
- Users can now import tracked job applications directly into the Interview Prep form.
- Selecting a job from the dropdown auto-fills:
  - Company name
  - Job title

This improves workflow and avoids manually re-entering application details.

## Validation

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [ ] `python -m compileall backend`

## Screenshots

Add screenshots showing:
1. Job added in Job Tracker
<img width="1489" height="545" alt="Screenshot 2026-05-22 144520" src="https://github.com/user-attachments/assets/6b9a62a9-6826-452e-b63c-25c4ae1310c7" />

2. Import dropdown in Interview Prep
<img width="1467" height="409" alt="Screenshot 2026-05-22 144538" src="https://github.com/user-attachments/assets/bb6b8614-d6b0-4881-b59b-d6e9664b4e69" />

3. Autofilled company + role fields
<img width="1487" height="403" alt="Screenshot 2026-05-22 144558" src="https://github.com/user-attachments/assets/d030a55c-227d-4feb-bd5d-2410099210a3" />


## Risks

- No database or API changes.
- No migration required.
- Feature only affects Interview Prep form autofill behavior.

Closes #94 
