### PR TITLE
fix: stabilize toast listener subscription lifecycle

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -167,14 +167,16 @@ function useToast() {
   const [state, setState] = React.useState<State>(memoryState);
 
   React.useEffect(() => {
-    listeners.push(setState);
-    return () => {
-      const index = listeners.indexOf(setState);
-      if (index > -1) {
-        listeners.splice(index, 1);
-      }
-    };
-  }, [state]);
+  listeners.push(setState);
+
+  return () => {
+    const index = listeners.indexOf(setState);
+
+    if (index > -1) {
+      listeners.splice(index, 1);
+    }
+  };
+}, []);
 
   return {
     ...state,


### PR DESCRIPTION
# Closes #132 
## Summary

* Fixes unnecessary toast listener re-registration during every toast state update.
* Updated `useToast()` effect lifecycle to make listener subscription mount-scoped instead of state-scoped.
* Prevents repeated subscribe/unsubscribe cycles and stabilizes global toast listener behavior.

## Validation

* [x] `npm run build`
* [ ] `npx tsc --noEmit`
* [ ] `python -m compileall backend`

## Screenshots

No UI changes.

## Risks

* Low risk change.
* No API, schema, or migration impact.
* Only affects internal toast listener lifecycle behavior.