### PR TITLE
fix: payload size for ML requests

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1041,7 +1041,7 @@ def require_current_user(
 def validate_payload_size(request: Request) -> None:
     if "content-length" in request.headers:
         length = int(request.headers["content-length"])
-        if length > 5242880: 
+        if length > 5242880:
             raise HTTPException(
                 status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
                 detail="Request entity too large",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1041,7 +1041,7 @@ def require_current_user(
 def validate_payload_size(request: Request) -> None:
     if "content-length" in request.headers:
         length = int(request.headers["content-length"])
-        if length > 10240:
+        if length > 5242880: 
             raise HTTPException(
                 status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
                 detail="Request entity too large",


### PR DESCRIPTION
Closes #146 
## Summary
this pr fixes a `413 request entity too large` error caused by the 10kb payload limit blocking valid ml requests (resumes and job desc) by increasing the `validate_payload_size` middleware limit in `backend/app/main.py`.

## Validation

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `python -m compileall backend`

## Screenshots

N/A

## Risks

None. 