### PR TITLE
fix: add input validation on session creation endpoint (closes #150)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,7 +25,7 @@ from fastapi import (
     status,
 )
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import (
     JSON,
     Boolean,
@@ -354,6 +354,13 @@ class CreateInterviewSessionRequest(BaseModel):
     company: str
     jdText: str = ""
     resumeText: str = ""
+
+    @field_validator("jobTitle", "company", mode="after")
+    @classmethod
+    def check_not_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("cannot be empty or whitespace-only")
+        return v
 
 
 class ConfidenceAnalysis(BaseModel):
@@ -1282,17 +1289,6 @@ async def create_session(
     _: UserTable = Depends(require_current_user),
     db: Session = Depends(get_db),
 ) -> InterviewSession:
-    if not payload.jobTitle.strip():
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="jobTitle cannot be empty or whitespace-only",
-        )
-    if not payload.company.strip():
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="company cannot be empty or whitespace-only",
-        )
-
     client = getattr(request.app.state, "httpx_client", None)
     gap_analysis, readiness, question_bank, roadmap = await generate_session_payload(
         payload.jobTitle,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1282,6 +1282,17 @@ async def create_session(
     _: UserTable = Depends(require_current_user),
     db: Session = Depends(get_db),
 ) -> InterviewSession:
+    if not payload.jobTitle.strip():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="jobTitle cannot be empty or whitespace-only",
+        )
+    if not payload.company.strip():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="company cannot be empty or whitespace-only",
+        )
+
     client = getattr(request.app.state, "httpx_client", None)
     gap_analysis, readiness, question_bank, roadmap = await generate_session_payload(
         payload.jobTitle,

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -382,6 +382,33 @@ class PrepIQApiTestCase(unittest.TestCase):
         self.assertEqual(mocks_after_delete.json()["items"], [])
         self.assertEqual(mocks_after_delete.json()["total"], 0)
 
+    def test_session_creation_validation(self) -> None:
+        user_id, headers = self.create_account()
+
+        res_empty_job = self.client.post(
+            f"/api/users/{user_id}/sessions",
+            headers=headers,
+            json={
+                "jobTitle": "   ",
+                "company": "PrepIQ",
+                "jdText": "Build React applications",
+                "resumeText": "Worked on React and TypeScript projects",
+            },
+        )
+        self.assertEqual(res_empty_job.status_code, 422)
+
+        res_empty_company = self.client.post(
+            f"/api/users/{user_id}/sessions",
+            headers=headers,
+            json={
+                "jobTitle": "Frontend Engineer",
+                "company": "   ",
+                "jdText": "Build React applications",
+                "resumeText": "Worked on React and TypeScript projects",
+            },
+        )
+        self.assertEqual(res_empty_company.status_code, 422)
+
     def test_generate_question_endpoint(self) -> None:
         user_id, headers = self.create_account()
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -396,6 +396,9 @@ class PrepIQApiTestCase(unittest.TestCase):
             },
         )
         self.assertEqual(res_empty_job.status_code, 422)
+        payload_job = res_empty_job.json()
+        self.assertEqual(payload_job["detail"][0]["loc"], ["body", "jobTitle"])
+        self.assertIn("cannot be empty or whitespace-only", payload_job["detail"][0]["msg"])
 
         res_empty_company = self.client.post(
             f"/api/users/{user_id}/sessions",
@@ -408,6 +411,9 @@ class PrepIQApiTestCase(unittest.TestCase):
             },
         )
         self.assertEqual(res_empty_company.status_code, 422)
+        payload_company = res_empty_company.json()
+        self.assertEqual(payload_company["detail"][0]["loc"], ["body", "company"])
+        self.assertIn("cannot be empty or whitespace-only", payload_company["detail"][0]["msg"])
 
     def test_generate_question_endpoint(self) -> None:
         user_id, headers = self.create_account()


### PR DESCRIPTION
Closes #150

## Summary

- **What problem does this PR solve?**
  The `POST /api/users/{user_id}/sessions` endpoint was previously accepting empty strings or whitespace-only inputs for `jobTitle` and `company`. This could result in corrupted AI generation calls and wasted API credits.
- **What changed?**
  - Added `.strip()` checks for `jobTitle` and `company` inside `create_session` in `backend/app/main.py` that return `422 Unprocessable Entity` if they are empty.
  - Added `test_session_creation_validation` in `backend/tests/test_api.py` to cover these new empty string validation cases.

## Validation

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `python -m compileall backend`

## Screenshots

*(N/A - Backend API validation only, no UI changes)*

## Risks

No breaking changes or deployment risks. Valid requests containing actual job titles and companies remain fully unaffected.