### PR TITLE
refactor: use require_current_user dependency on me endpoint (closes …

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1153,20 +1153,9 @@ def signup(payload: SignupRequest, db: Session = Depends(get_db)) -> AuthRespons
 
 @app.get("/api/auth/me", response_model=User)
 def me(
-    authorization: str | None = Header(default=None), db: Session = Depends(get_db)
+    current_user: UserTable = Depends(require_current_user)
 ) -> User:
-    if not authorization or not authorization.startswith("Bearer "):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Missing authorization token",
-        )
-    payload = decode_token(authorization.removeprefix("Bearer ").strip())
-    user = db.get(UserTable, payload.get("sub"))
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found"
-        )
-    return user_from_table(user)
+    return user_from_table(current_user)
 
 
 @app.get("/api/users/{user_id}/profile", response_model=CareerProfile | None)


### PR DESCRIPTION
Closes #151

## Summary

- **What problem does this PR solve?**
  The `GET /api/auth/me` endpoint in `backend/app/main.py` was previously manually extracting and decoding the JWT token. This duplicated logic that was already centralized and handled by the `require_current_user` dependency, creating unnecessary redundancy and potential inconsistencies in how authentication was enforced.
- **What changed?**
  - Refactored the `me` endpoint in `backend/app/main.py` to use `current_user: UserTable = Depends(require_current_user)`.
  - Removed all duplicated JWT parsing, decoding, and user lookup logic.
  - The response model and behavior of the endpoint remain completely unchanged.

## Validation

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `python -m compileall backend`

## Screenshots

*(N/A - Backend refactoring only, no UI changes)*

## Risks

No breaking changes or deployment risks. The authentication logic relies on the exact same dependency used across other secure endpoints.