### PR TITLE
fix: validate graduation year on onboarding page

### DIFF
--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -67,8 +67,8 @@ const SearchableMultiSelect = ({ options, selected, onChange, placeholder }: { o
   const [query, setQuery] = useState("");
   const [isOpen, setIsOpen] = useState(false);
 
-  const filteredOptions = options.filter(opt => 
-    opt.toLowerCase().includes(query.toLowerCase()) && 
+  const filteredOptions = options.filter(opt =>
+    opt.toLowerCase().includes(query.toLowerCase()) &&
     !selected.some(s => s.toLowerCase() === opt.toLowerCase())
   );
 
@@ -232,17 +232,21 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
           return "Please enter your institution.";
         if (!graduationYear.trim())
           return "Please enter your graduation year.";
+        const year = parseInt(graduationYear, 10);
+        if (isNaN(year) || year < 1950 || year > 2030)
+          return "Please enter a valid graduation year between 1950 and 2030.";
+
         return null;
       case 2: {
         let filledCount = 0;
         const currentYear = new Date().getFullYear();
-        
+
         for (const entry of workHistory) {
           const isFilled = entry.jobTitle.trim() || entry.company.trim() || entry.from.trim() || entry.to.trim();
           if (!isFilled) continue;
-          
+
           filledCount++;
-          
+
           if (!entry.jobTitle.trim() || !entry.company.trim()) {
             return "Please provide both job title and company for all work entries.";
           }
@@ -250,7 +254,7 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
           if (entry.from.trim()) {
             const startYearMatch = entry.from.match(/\b(19|20)\d{2}\b/);
             if (!startYearMatch) return "Please include a valid year (e.g., 2020) in the 'From' field.";
-            
+
             const startYear = parseInt(startYearMatch[0], 10);
             if (startYear > currentYear) return `Start year (${startYear}) cannot be in the future.`;
             if (startYear < 1950) return `Start year (${startYear}) is unrealistic.`;
@@ -258,11 +262,11 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
             if (entry.to.trim()) {
               const isPresent = entry.to.toLowerCase() === "present" || entry.to.toLowerCase() === "current";
               const endYearMatch = entry.to.match(/\b(19|20)\d{2}\b/);
-              
+
               if (!endYearMatch && !isPresent) return "Please include a valid year or 'Present' in the 'To' field.";
-              
+
               const endYear = endYearMatch ? parseInt(endYearMatch[0], 10) : currentYear;
-              
+
               if (!isPresent && endYear > currentYear) return `End year (${endYear}) cannot be in the future.`;
               if (endYear < startYear) return `End year (${endYear}) must be greater than or equal to start year (${startYear}).`;
             }
@@ -272,7 +276,7 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
         if (filledCount === 0) {
           return "Add at least one work entry with job title and company.";
         }
-        
+
         return null;
       }
       case 3:
@@ -341,8 +345,8 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
     }
   };
 
-  const filteredTechOptions = PREDEFINED_TECH_SKILLS.filter(opt => 
-    opt.toLowerCase().includes(techQuery.toLowerCase()) && 
+  const filteredTechOptions = PREDEFINED_TECH_SKILLS.filter(opt =>
+    opt.toLowerCase().includes(techQuery.toLowerCase()) &&
     !technicalSkills.some(s => s.name.toLowerCase() === opt.toLowerCase())
   );
 
@@ -407,7 +411,7 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
                   </div>
                   <div>
                     <Label>Graduation Year</Label>
-                    <Input value={graduationYear} onChange={(e) => setGraduationYear(e.target.value)} className="mt-1 bg-secondary/50" />
+                    <Input type="number" min="1950" max="2030" value={graduationYear} onChange={(e) => setGraduationYear(e.target.value)} className="mt-1 bg-secondary/50" />
                   </div>
                   <div>
                     <Label>Relevant Coursework</Label>


### PR DESCRIPTION
## Summary

- **What problem does this PR solve?** 
  Closes #145. The Graduation Year input field in the Education step previously accepted arbitrary text values (like "dfghjkl"), allowing users to submit invalid academic information which affected data integrity.

- **What changed?** 
  - Changed the graduation year input `type` to `number` with `min="1950"` and `max="2030"` limits.
  - Added form validation logic to `validateStep` to show an inline error message and block form progression if the entered year is invalid or outside the acceptable range.

## Validation

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `python -m compileall backend`

## Screenshots
<img width="907" height="804" alt="image" src="https://github.com/user-attachments/assets/dd7dd660-8c25-45fd-8822-2bcf696f5906" />

<img width="1083" height="794" alt="image" src="https://github.com/user-attachments/assets/9a8d9bec-65d5-4b13-aa69-a4c056249ce2" />


## Risks

None. No database migrations or API changes were required.
