### PR TITLE
fix: synchronize profile email with authenticated user identity

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1183,7 +1183,7 @@ def get_profile(
 def save_profile(
     user_id: str,
     profile: CareerProfile,
-    _: UserTable = Depends(require_current_user),
+    user: UserTable = Depends(require_current_user),
     db: Session = Depends(get_db),
 ) -> CareerProfile:
     if profile.userId != user_id:
@@ -1192,6 +1192,7 @@ def save_profile(
         )
 
     payload = profile.model_dump(by_alias=True)
+    payload["email"] = user.email
     existing = db.get(ProfileTable, user_id)
     if existing:
         existing.full_name = payload["fullName"]


### PR DESCRIPTION
## Summary

* Fixes profile email desynchronization from authenticated account identity.
* Backend now ignores client-provided profile email values during profile save operations.
* `ProfileTable.email` is always synchronized with the authenticated `UserTable.email`.

## Validation

* [x] `python -m compileall backend`
* [x] `npx tsc --noEmit`
* [ ] `npm run build` *(currently failing upstream due to unresolved `jspdf` dependency unrelated to this backend-only change)*
* [x] `npm test`

## Risks

* Low-risk backend-only change.
* No migration or schema impact.
* Improves account identity consistency across authenticated profile state.

Closes #134 