### PR TITLE
feat: add privacy policy and terms pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AppLayout } from "@/components/AppLayout";
 import { useAuth, useCareerProfile, useInterviewSessions, useMockAttempts, useJobApplications } from "@/lib/store";
+import Privacy from "./pages/Privacy";
+import Terms from "./pages/Terms";
 
 const Index = lazy(() => import("./pages/Index"));
 const NotFound = lazy(() => import("./pages/NotFound"));
@@ -18,8 +20,6 @@ const InterviewPrepPage = lazy(() => import("./pages/InterviewPrepPage"));
 const MockInterviewPage = lazy(() => import("./pages/MockInterviewPage"));
 const JobTrackerPage = lazy(() => import("./pages/JobTrackerPage"));
 const ProgressPage = lazy(() => import("./pages/ProgressPage"));
-const Privacy = lazy(() => import("./pages/Privacy"));
-const Terms = lazy(() => import("./pages/Terms"));
 
 const queryClient = new QueryClient();
 
@@ -103,19 +103,7 @@ function ProtectedRoute({ hydrated, user, logout, resourceErrorMessage, children
 }
 
 function AppRoutes() {
-  const {
-    login,
-    signup,
-    logout,
-  } = useAuth();
-
-  const hydrated = true;
-
-  const user = {
-    id: "demo-user",
-    name: "Demo User",
-    email: "demo@example.com",
-  };
+  const { user, login, signup, logout, hydrated } = useAuth();
   const { profile, saveProfile, profileError } = useCareerProfile(user?.id);
   const { sessions, addSession, sessionsError } = useInterviewSessions(user?.id);
   const { attempts, addAttempt, attemptsError } = useMockAttempts(user?.id);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,7 +87,7 @@ interface ProtectedRouteProps {
 
 function ProtectedRoute({ hydrated, user, logout, resourceErrorMessage, children }: ProtectedRouteProps) {
   if (!hydrated) return <RouteFallback />;
-  if (false && !user) return <Navigate to="/login" replace />;
+  if (!user) return <Navigate to="/login" replace />;
   return (
     <AppLayout onLogout={logout}>
       <div className="space-y-4">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,8 @@ const InterviewPrepPage = lazy(() => import("./pages/InterviewPrepPage"));
 const MockInterviewPage = lazy(() => import("./pages/MockInterviewPage"));
 const JobTrackerPage = lazy(() => import("./pages/JobTrackerPage"));
 const ProgressPage = lazy(() => import("./pages/ProgressPage"));
+const Privacy = lazy(() => import("./pages/Privacy"));
+const Terms = lazy(() => import("./pages/Terms"));
 
 const queryClient = new QueryClient();
 
@@ -85,7 +87,7 @@ interface ProtectedRouteProps {
 
 function ProtectedRoute({ hydrated, user, logout, resourceErrorMessage, children }: ProtectedRouteProps) {
   if (!hydrated) return <RouteFallback />;
-  if (!user) return <Navigate to="/login" replace />;
+  if (false && !user) return <Navigate to="/login" replace />;
   return (
     <AppLayout onLogout={logout}>
       <div className="space-y-4">
@@ -101,7 +103,19 @@ function ProtectedRoute({ hydrated, user, logout, resourceErrorMessage, children
 }
 
 function AppRoutes() {
-  const { user, login, signup, logout, hydrated } = useAuth();
+  const {
+    login,
+    signup,
+    logout,
+  } = useAuth();
+
+  const hydrated = true;
+
+  const user = {
+    id: "demo-user",
+    name: "Demo User",
+    email: "demo@example.com",
+  };
   const { profile, saveProfile, profileError } = useCareerProfile(user?.id);
   const { sessions, addSession, sessionsError } = useInterviewSessions(user?.id);
   const { attempts, addAttempt, attemptsError } = useMockAttempts(user?.id);
@@ -126,6 +140,22 @@ function AppRoutes() {
         <Route path="/mock-interview" element={<ProtectedRoute hydrated={hydrated} user={user} logout={logout} resourceErrorMessage={resourceErrorMessage}><MockInterviewPage sessions={sessions} attempts={attempts} onAddAttempt={addAttempt} userId={user?.id || ""} /></ProtectedRoute>} />
         <Route path="/job-tracker" element={<ProtectedRoute hydrated={hydrated} user={user} logout={logout} resourceErrorMessage={resourceErrorMessage}><JobTrackerPage jobs={jobs} sessions={sessions} onAddJob={addJob} onUpdateJob={updateJob} onDeleteJob={deleteJob} userId={user?.id || ""} /></ProtectedRoute>} />
         <Route path="/progress" element={<ProtectedRoute hydrated={hydrated} user={user} logout={logout} resourceErrorMessage={resourceErrorMessage}><ProgressPage mocks={attempts} sessions={sessions} /></ProtectedRoute>} />
+        <Route
+          path="/privacy-policy"
+          element={
+            <AppLayout onLogout={logout}>
+              <Privacy />
+            </AppLayout>
+          }
+        />
+        <Route
+          path="/terms"
+          element={
+            <AppLayout onLogout={logout}>
+              <Terms />
+            </AppLayout>
+          }
+        />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </Suspense>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -107,6 +107,26 @@ export function AppSidebar({ onLogout }: AppSidebarProps) {
 
       <SidebarFooter className="border-t border-border p-2">
         <SidebarMenu>
+
+          {!collapsed && (
+            <div className="px-3 pb-3 mb-2 border-b border-border/60 flex flex-col gap-2">
+
+              <NavLink
+                to="/privacy-policy"
+                className="text-[12px] text-muted-foreground hover:text-primary underline underline-offset-4 transition-colors"
+              >
+                Privacy Policy
+              </NavLink>
+
+              <NavLink
+                to="/terms"
+                className="text-[12px] text-muted-foreground hover:text-primary underline underline-offset-4 transition-colors"
+              >
+                Terms & Conditions
+              </NavLink>
+
+            </div>
+          )}
           <SidebarMenuItem>
             <SidebarMenuButton
               onClick={toggleTheme}

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,0 +1,200 @@
+import { motion } from "framer-motion";
+import { ShieldCheck, Lock, Database, Eye, Mail } from "lucide-react";
+
+export default function Privacy() {
+    return (
+        <div className="space-y-6 animate-slide-up">
+
+
+            <motion.div
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="rounded-2xl gradient-primary p-6 shadow-glow"
+            >
+                <div className="flex items-center gap-3">
+                    <ShieldCheck className="w-8 h-8 text-primary-foreground" />
+
+                    <div>
+                        <h1 className="text-2xl font-bold text-primary-foreground">
+                            Privacy Policy
+                        </h1>
+
+                        <p className="text-primary-foreground/80 text-sm">
+                            Learn how PrepIQ collects, stores, and protects your data.
+                        </p>
+                    </div>
+                </div>
+            </motion.div>
+
+
+            <div className="rounded-2xl bg-card border border-border p-8 md:p-10 space-y-10">
+
+                <section className="space-y-4">
+
+                    <h2 className="text-2xl font-bold text-foreground">
+                        Introduction
+                    </h2>
+
+                    <p className="text-muted-foreground leading-8 text-[15px]">
+                        PrepIQ is a full-stack interview preparation platform
+                        designed to help users prepare smarter for technical
+                        interviews, track applications, and improve career readiness
+                        through AI-assisted workflows and analytics.
+                    </p>
+
+                    <p className="text-muted-foreground leading-8 text-[15px]">
+                        This Privacy Policy explains how we collect, use,
+                        and safeguard your information while using the platform.
+                    </p>
+
+                </section>
+
+                <section className="space-y-5">
+
+                    <div className="flex items-center gap-3">
+
+                        <Database className="w-5 h-5 text-primary" />
+
+                        <h2 className="text-2xl font-bold text-foreground">
+                            Information We Collect
+                        </h2>
+
+                    </div>
+
+                    <ul className="space-y-4 text-muted-foreground leading-8 text-[15px]">
+
+                        <li>
+                            • Account information such as name, email address,
+                            authentication credentials, and onboarding data
+                        </li>
+
+                        <li>
+                            • Career DNA profiling information including skills,
+                            experience level, goals, and preparation preferences
+                        </li>
+
+                        <li>
+                            • Mock interview sessions, AI-generated feedback,
+                            preparation history, and analytics data
+                        </li>
+
+                        <li>
+                            • Job application tracking information including
+                            company names, statuses, notes, and timelines
+                        </li>
+
+                        <li>
+                            • Usage analytics and interaction data used to
+                            improve platform performance and recommendations
+                        </li>
+
+                    </ul>
+
+                </section>
+
+                <section className="space-y-5">
+
+                    <div className="flex items-center gap-3">
+
+                        <Eye className="w-5 h-5 text-primary" />
+
+                        <h2 className="text-2xl font-bold text-foreground">
+                            How We Use Your Data
+                        </h2>
+
+                    </div>
+
+                    <ul className="space-y-4 text-muted-foreground leading-8 text-[15px]">
+
+                        <li>
+                            • Generate personalized interview preparation plans
+                            and study roadmaps
+                        </li>
+
+                        <li>
+                            • Provide AI-assisted feedback for mock interviews
+                            and preparation sessions
+                        </li>
+
+                        <li>
+                            • Track preparation progress, interview scores,
+                            and learning analytics
+                        </li>
+
+                        <li>
+                            • Improve NLP and AI-powered recommendation systems
+                        </li>
+
+                        <li>
+                            • Maintain account security and prevent unauthorized access
+                        </li>
+
+                    </ul>
+
+                </section>
+
+                <section className="space-y-5">
+
+                    <div className="flex items-center gap-3">
+
+                        <Lock className="w-5 h-5 text-primary" />
+
+                        <h2 className="text-2xl font-bold text-foreground">
+                            Security & Protection
+                        </h2>
+
+                    </div>
+
+                    <p className="text-muted-foreground leading-8 text-[15px]">
+                        PrepIQ uses secure authentication mechanisms,
+                        encrypted communication, and industry-standard
+                        practices to protect user accounts and personal data.
+                    </p>
+
+                    <p className="text-muted-foreground leading-8 text-[15px]">
+                        Passwords are securely hashed and sensitive operations
+                        are protected through token-based authentication systems.
+                    </p>
+
+                </section>
+
+                <section className="space-y-5">
+
+                    <h2 className="text-2xl font-bold text-foreground">
+                        Technologies Used
+                    </h2>
+
+                    <p className="text-muted-foreground leading-8 text-[15px]">
+                        PrepIQ is built using React, TypeScript, FastAPI,
+                        PostgreSQL, Tailwind CSS, Framer Motion,
+                        OpenRouter AI models, spaCy NLP,
+                        scikit-learn, and other modern technologies
+                        to deliver an interactive interview preparation experience.
+                    </p>
+
+                </section>
+
+                <section className="space-y-5">
+
+                    <div className="flex items-center gap-3">
+
+                        <Mail className="w-5 h-5 text-primary" />
+
+                        <h2 className="text-2xl font-bold text-foreground">
+                            Contact Us
+                        </h2>
+
+                    </div>
+
+                    <p className="text-muted-foreground leading-8 text-[15px]">
+                        If you have questions regarding this Privacy Policy,
+                        data handling, or account security,
+                        you may contact the PrepIQ team for support and clarification.
+                    </p>
+
+                </section>
+
+            </div>
+        </div>
+    );
+}

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,0 +1,188 @@
+import { motion } from "framer-motion";
+import { FileText, ShieldCheck, AlertTriangle, Scale, Mail } from "lucide-react";
+
+export default function Terms() {
+    return (
+        <div className="space-y-6 animate-slide-up">
+
+            <motion.div
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="rounded-2xl gradient-primary p-6 shadow-glow"
+            >
+                <div className="flex items-center gap-3">
+
+                    <FileText className="w-8 h-8 text-primary-foreground" />
+
+                    <div>
+
+                        <h1 className="text-2xl font-bold text-primary-foreground">
+                            Terms & Conditions
+                        </h1>
+
+                        <p className="text-primary-foreground/80 text-sm">
+                            Please read these terms carefully before using PrepIQ.
+                        </p>
+
+                    </div>
+                </div>
+            </motion.div>
+
+            <div className="rounded-2xl bg-card border border-border p-8 md:p-10 space-y-10">
+
+                <section className="space-y-4">
+
+                    <h2 className="text-2xl font-bold text-foreground">
+                        Introduction
+                    </h2>
+
+                    <p className="text-muted-foreground leading-8 text-[15px]">
+                        Welcome to PrepIQ. By accessing or using the platform,
+                        you agree to comply with and be bound by these
+                        Terms & Conditions.
+                    </p>
+
+                    <p className="text-muted-foreground leading-8 text-[15px]">
+                        PrepIQ provides interview preparation tools,
+                        AI-assisted mock interviews, progress tracking,
+                        and job application management features
+                        for educational and career development purposes.
+                    </p>
+
+                </section>
+
+                <section className="space-y-5">
+
+                    <div className="flex items-center gap-3">
+
+                        <ShieldCheck className="w-5 h-5 text-primary" />
+
+                        <h2 className="text-2xl font-bold text-foreground">
+                            User Responsibilities
+                        </h2>
+
+                    </div>
+
+                    <ul className="space-y-4 text-muted-foreground leading-8 text-[15px]">
+
+                        <li>
+                            • Users are responsible for maintaining
+                            the confidentiality of their accounts
+                            and login credentials
+                        </li>
+
+                        <li>
+                            • You agree to provide accurate information
+                            during onboarding and platform usage
+                        </li>
+
+                        <li>
+                            • Users must not misuse the platform,
+                            exploit vulnerabilities, or attempt
+                            unauthorized access
+                        </li>
+
+                        <li>
+                            • AI-generated recommendations should be used
+                            as guidance and not as guaranteed outcomes
+                        </li>
+
+                    </ul>
+
+                </section>
+
+                <section className="space-y-5">
+
+                    <div className="flex items-center gap-3">
+
+                        <Scale className="w-5 h-5 text-primary" />
+
+                        <h2 className="text-2xl font-bold text-foreground">
+                            Platform Usage
+                        </h2>
+
+                    </div>
+
+                    <p className="text-muted-foreground leading-8 text-[15px]">
+                        PrepIQ is intended for educational,
+                        interview preparation, and career tracking purposes.
+                    </p>
+
+                    <p className="text-muted-foreground leading-8 text-[15px]">
+                        We reserve the right to modify, suspend,
+                        or discontinue features at any time
+                        to improve platform stability and performance.
+                    </p>
+
+                </section>
+                <section className="space-y-5">
+
+                    <div className="flex items-center gap-3">
+
+                        <AlertTriangle className="w-5 h-5 text-primary" />
+
+                        <h2 className="text-2xl font-bold text-foreground">
+                            AI & Recommendation Disclaimer
+                        </h2>
+
+                    </div>
+
+                    <p className="text-muted-foreground leading-8 text-[15px]">
+                        PrepIQ uses AI-powered systems for mock interview
+                        feedback, preparation recommendations,
+                        and analytics generation.
+                    </p>
+
+                    <p className="text-muted-foreground leading-8 text-[15px]">
+                        While we strive for accuracy,
+                        AI-generated outputs may occasionally
+                        contain inaccuracies or incomplete suggestions.
+                    </p>
+
+                </section>
+
+                <section className="space-y-5">
+
+                    <h2 className="text-2xl font-bold text-foreground">
+                        Limitation of Liability
+                    </h2>
+
+                    <p className="text-muted-foreground leading-8 text-[15px]">
+                        PrepIQ shall not be held responsible
+                        for interview outcomes, hiring decisions,
+                        or career opportunities resulting from
+                        platform usage.
+                    </p>
+
+                    <p className="text-muted-foreground leading-8 text-[15px]">
+                        Users are solely responsible for how they
+                        apply interview preparation materials
+                        and recommendations.
+                    </p>
+
+                </section>
+                <section className="space-y-5">
+
+                    <div className="flex items-center gap-3">
+
+                        <Mail className="w-5 h-5 text-primary" />
+
+                        <h2 className="text-2xl font-bold text-foreground">
+                            Contact Us
+                        </h2>
+
+                    </div>
+
+                    <p className="text-muted-foreground leading-8 text-[15px]">
+                        If you have any questions regarding these
+                        Terms & Conditions, you may contact
+                        the PrepIQ team for support and clarification.
+                    </p>
+
+                </section>
+
+            </div>
+
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
Closes #138 

- What problem does this PR solve?
       - Currently the platform takes user data but does not contain a proper privacy policy or terms and conditions page to tell users about how the data is being used. 
- What changed?
        - Added privacy policy and terms and conditions page. 
        - Added them into the sidebar footer so that they can be accessed from there. 
        - Ensured consistent design
        - Ensured responsiveness

## Validation

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `python -m compileall backend`

## Screenshots

<img width="1919" height="865" alt="image" src="https://github.com/user-attachments/assets/3d0aceaf-5982-452e-8ee6-022bd8fd0655" />
<img width="1919" height="872" alt="image" src="https://github.com/user-attachments/assets/ce3e41e2-7acf-4e03-8d3a-eb9b30776740" />


## Risks

NA

AI usage: Commit message and privacy and terms content written by AI but checked and only relevant content kept for the platform. 
