### PR TITLE
fix: improve transparency for estimated gap analysis

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -140,6 +140,7 @@ class InterviewSessionTable(Base):
     company: Mapped[str] = mapped_column(String(255))
     jd_text: Mapped[str] = mapped_column(Text)
     resume_text: Mapped[str] = mapped_column(Text)
+    is_estimated: Mapped[bool] = mapped_column(Boolean, default=False)
     gap_analysis: Mapped[list[dict[str, Any]]] = mapped_column(JSON)
     readiness_score: Mapped[int] = mapped_column(Integer)
     question_bank: Mapped[list[dict[str, Any]]] = mapped_column(JSON)
@@ -340,6 +341,7 @@ class InterviewSession(BaseModel):
     company: str
     jdText: str
     resumeText: str
+    isEstimated: bool
     gapAnalysis: list[GapItem]
     readinessScore: int
     questionBank: list[QuestionItem]
@@ -478,6 +480,7 @@ def session_from_table(session: InterviewSessionTable) -> InterviewSession:
         company=session.company,
         jdText=session.jd_text,
         resumeText=session.resume_text,
+        isEstimated=session.is_estimated,
         gapAnalysis=session.gap_analysis,
         readinessScore=session.readiness_score,
         questionBank=session.question_bank,
@@ -724,7 +727,7 @@ async def generate_session_payload(
         roadmap = [RoadmapDay(**norm_dict(item, roadmap_mapping)) for item in raw_roadmap if isinstance(item, dict)]
 
         if len(roadmap) >= 1 and len(question_bank) >= 1 and len(gap_analysis) >= 1:
-            return gap_analysis, readiness, question_bank, roadmap
+            return gap_analysis, readiness, question_bank, roadmap, False
     except (OpenRouterError, KeyError, TypeError, ValueError) as exc:
         logger.warning(
             "Using fallback prep session payload because OpenRouter failed: %s", exc
@@ -826,7 +829,8 @@ async def generate_session_payload(
             ],
         ),
     ]
-    return gap_analysis, readiness, question_bank, roadmap
+    is_estimated = not resume_text.strip() and not jd_text.strip()
+    return gap_analysis, readiness, question_bank, roadmap, is_estimated
 
 
 def _significant_tokens(text: str) -> set[str]:
@@ -1283,7 +1287,7 @@ async def create_session(
     db: Session = Depends(get_db),
 ) -> InterviewSession:
     client = getattr(request.app.state, "httpx_client", None)
-    gap_analysis, readiness, question_bank, roadmap = await generate_session_payload(
+    gap_analysis, readiness, question_bank, roadmap, is_estimated = await generate_session_payload(
         payload.jobTitle,
         payload.company,
         payload.jdText,
@@ -1302,6 +1306,7 @@ async def create_session(
         company=payload.company,
         jd_text=payload.jdText,
         resume_text=payload.resumeText,
+        is_estimated=is_estimated,
         gap_analysis=[item.model_dump() for item in gap_analysis],
         readiness_score=readiness,
         question_bank=[item.model_dump() for item in question_bank],

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -58,6 +58,7 @@ export interface InterviewSession {
   roadmap: RoadmapDay[];
   extractedSkills: string[];
   mlMatchScore: number;
+  isEstimated: boolean;
   createdAt: string;
 }
 

--- a/src/pages/InterviewPrepPage.tsx
+++ b/src/pages/InterviewPrepPage.tsx
@@ -317,12 +317,21 @@ export default function InterviewPrepPage({
             <div className="space-y-4">
               <div className="bg-card border border-border rounded-2xl p-6 shadow-card">
                 <h3 className="text-lg font-semibold mb-4">Skill Gap Analysis</h3>
+                {activeSession.isEstimated && (
+                  <div className="mb-4 rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-4 text-sm text-yellow-200">
+                    Analysis is AI-inferred from role/company name only — add your resume and JD for personalized results.
+                  </div>
+                )}
                 <div className="overflow-x-auto">
                   <table className="w-full text-sm">
                     <thead>
                       <tr className="border-b border-border">
                         <th className="text-left py-3 text-muted-foreground font-medium">Skill</th>
-                        <th className="text-left py-3 text-muted-foreground font-medium">You Have</th>
+                        <th className="text-left py-3 text-muted-foreground font-medium">
+                          {activeSession.isEstimated && !activeSession.resumeText && !activeSession.jdText
+                            ? "You Have (Estimated)"
+                            : "You Have"}
+                        </th>
                         <th className="text-left py-3 text-muted-foreground font-medium">They Need</th>
                         <th className="text-left py-3 text-muted-foreground font-medium">Gap Level</th>
                       </tr>


### PR DESCRIPTION
## Summary

This PR improves transparency when fallback/inferred gap analysis data is shown in Interview Prep sessions.

Closes #142

## Changes made

- Added an isEstimated flag in the backend response when fallback gap analysis is used
- Added a warning banner in the frontend when both resume and JD fields are empty
- Updated the "You Have" column label to "You Have (Estimated)" when inferred fallback data is displayed

## Validation

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `python -m compileall backend`

## Screenshots

<img width="1470" height="802" alt="Screenshot 2026-05-28 at 4 29 53 PM" src="https://github.com/user-attachments/assets/5f45e153-6355-4f03-9e6b-126346b1bc2b" />


## Risks

- Added new isEstimated field to session response/store
- No migration required
- No existing functionality removed
