### PR TITLE
Feat/mentor chat history toggle

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -122,7 +122,9 @@ class UserTable(Base):
     email: Mapped[str] = mapped_column(String(255), unique=True, index=True)
     password_hash: Mapped[str] = mapped_column(String(255))
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
-    mentor_history_enabled: Mapped[bool] = mapped_column(Boolean, server_default="true", default=True)
+    mentor_history_enabled: Mapped[bool] = mapped_column(
+        Boolean, server_default="true", default=True
+    )
 
 
 class ProfileTable(Base):
@@ -1952,7 +1954,7 @@ async def mentor_chat(
     history = payload.history or []
     conv_id = payload.conversation_id
     now = utc_now()
-    
+
     is_persistent = current_user.mentor_history_enabled
 
     if is_persistent:
@@ -1972,7 +1974,7 @@ async def mentor_chat(
             )
             if not conv:
                 raise HTTPException(status_code=404, detail="Conversation not found")
-    
+
             # Load history
             stmt = (
                 select(MentorChatMessageTable)
@@ -2027,14 +2029,16 @@ async def mentor_chat(
                     created_at=utc_now(),
                 )
             )
-    
+
             # Update conversation updated_at
             conv_to_update = db.scalar(
-                select(MentorConversationTable).where(MentorConversationTable.id == conv_id)
+                select(MentorConversationTable).where(
+                    MentorConversationTable.id == conv_id
+                )
             )
             if conv_to_update:
                 conv_to_update.updated_at = utc_now()
-    
+
             db.commit()
 
         return MentorChatResponse(reply=reply_text, conversation_id=conv_id)
@@ -2052,22 +2056,32 @@ class ConversationResponse(BaseModel):
     title: str
     updated_at: str
 
+
 class MentorSettingsResponse(BaseModel):
     mentor_history_enabled: bool
+
 
 class MentorSettingsUpdateRequest(BaseModel):
     mentor_history_enabled: bool
 
-@app.get("/api/users/{user_id}/mentor-chat/settings", response_model=MentorSettingsResponse)
+
+@app.get(
+    "/api/users/{user_id}/mentor-chat/settings", response_model=MentorSettingsResponse
+)
 def get_mentor_settings(
     user_id: str,
     current_user: UserTable = Depends(require_current_user),
 ) -> MentorSettingsResponse:
     if current_user.id != user_id:
         raise HTTPException(status_code=403, detail="Forbidden")
-    return MentorSettingsResponse(mentor_history_enabled=current_user.mentor_history_enabled)
+    return MentorSettingsResponse(
+        mentor_history_enabled=current_user.mentor_history_enabled
+    )
 
-@app.patch("/api/users/{user_id}/mentor-chat/settings", response_model=MentorSettingsResponse)
+
+@app.patch(
+    "/api/users/{user_id}/mentor-chat/settings", response_model=MentorSettingsResponse
+)
 def update_mentor_settings(
     user_id: str,
     payload: MentorSettingsUpdateRequest,
@@ -2076,10 +2090,13 @@ def update_mentor_settings(
 ) -> MentorSettingsResponse:
     if current_user.id != user_id:
         raise HTTPException(status_code=403, detail="Forbidden")
-    
+
     current_user.mentor_history_enabled = payload.mentor_history_enabled
     db.commit()
-    return MentorSettingsResponse(mentor_history_enabled=current_user.mentor_history_enabled)
+    return MentorSettingsResponse(
+        mentor_history_enabled=current_user.mentor_history_enabled
+    )
+
 
 @app.get(
     "/api/users/{user_id}/mentor-chat/conversations",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,15 +10,14 @@ import os
 import re
 import secrets
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, Literal
 from uuid import uuid4
-# pyrefly: ignore [missing-import]
-from dotenv import load_dotenv
-from pathlib import Path
-
-load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 
 import httpx
+
+# pyrefly: ignore [missing-import]
+from dotenv import load_dotenv
 from fastapi import (
     Depends,
     FastAPI,
@@ -35,6 +34,7 @@ from sqlalchemy import (
     JSON,
     Boolean,
     DateTime,
+    ForeignKey,
     Integer,
     String,
     Text,
@@ -42,11 +42,12 @@ from sqlalchemy import (
     delete,
     func,
     select,
-    ForeignKey,
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, sessionmaker
 
 from .ml import analyze_confidence, compute_match_score, extract_skills
+
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 
 logger = logging.getLogger(__name__)
 
@@ -206,18 +207,28 @@ class MentorConversationTable(Base):
     id: Mapped[str] = mapped_column(String(36), primary_key=True)
     user_id: Mapped[str] = mapped_column(String(36), index=True)
     title: Mapped[str] = mapped_column(String(255))
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
-    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now, onupdate=utc_now
+    )
 
 
 class MentorChatMessageTable(Base):
     __tablename__ = "mentor_chat_messages"
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True)
-    conversation_id: Mapped[str] = mapped_column(String(36), ForeignKey("mentor_conversations.id", ondelete="CASCADE"), index=True)
-    role: Mapped[str] = mapped_column(String(20)) # "user" or "assistant"
+    conversation_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("mentor_conversations.id", ondelete="CASCADE"),
+        index=True,
+    )
+    role: Mapped[str] = mapped_column(String(20))  # "user" or "assistant"
     content: Mapped[str] = mapped_column(Text)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now
+    )
 
 
 def get_db() -> Session:
@@ -556,7 +567,10 @@ def stable_number(seed: str, minimum: int, maximum: int) -> int:
 
 
 async def call_openrouter_json(
-    system_prompt: str, user_prompt: str, client: httpx.AsyncClient | None = None, history: list[dict[str, str]] | None = None
+    system_prompt: str,
+    user_prompt: str,
+    client: httpx.AsyncClient | None = None,
+    history: list[dict[str, str]] | None = None,
 ) -> dict[str, Any]:
     if GEMINI_API_KEY:
         url = "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
@@ -568,7 +582,9 @@ async def call_openrouter_json(
         provider_name = "Gemini"
     else:
         if not OPENROUTER_API_KEY:
-            raise OpenRouterError("No API key configured (neither Gemini nor OpenRouter)")
+            raise OpenRouterError(
+                "No API key configured (neither Gemini nor OpenRouter)"
+            )
         url = "https://openrouter.ai/api/v1/chat/completions"
         model = OPENROUTER_MODEL
         headers = {
@@ -622,8 +638,7 @@ async def call_openrouter_json(
                         backoff = 2**attempt
 
                     logger.warning(
-                        "%s returned status %d. Retrying in %ds "
-                        "(attempt %d/%d)...",
+                        "%s returned status %d. Retrying in %ds (attempt %d/%d)...",
                         provider_name,
                         response.status_code,
                         backoff,
@@ -649,7 +664,9 @@ async def call_openrouter_json(
             raise OpenRouterError(f"{provider_name} connection failed: {exc}") from exc
 
     if not body:
-        raise OpenRouterError(f"{provider_name} request failed to return a response body")
+        raise OpenRouterError(
+            f"{provider_name} request failed to return a response body"
+        )
 
     try:
         raw_content = body["choices"][0]["message"]["content"]
@@ -665,8 +682,9 @@ async def call_openrouter_json(
             content = content.strip()
         return json.loads(content)
     except (KeyError, IndexError, TypeError, json.JSONDecodeError) as exc:
-        raise OpenRouterError(f"{provider_name} returned an invalid response format") from exc
-
+        raise OpenRouterError(
+            f"{provider_name} returned an invalid response format"
+        ) from exc
 
 
 async def generate_session_payload(
@@ -725,31 +743,43 @@ async def generate_session_payload(
             "skill": ["skill", "name"],
             "have": ["have", "current"],
             "need": ["need", "required"],
-            "gapLevel": ["gaplevel", "level", "gap"]
+            "gapLevel": ["gaplevel", "level", "gap"],
         }
         q_mapping = {
             "question": ["question", "text"],
             "type": ["type", "category"],
             "difficulty": ["difficulty", "level"],
-            "tip": ["tip", "hint"]
+            "tip": ["tip", "hint"],
         }
         roadmap_mapping = {
             "day": ["day", "number"],
             "focusArea": ["focusarea", "area", "focus"],
-            "tasks": ["tasks", "todo"]
+            "tasks": ["tasks", "todo"],
         }
 
         raw_gap = norm_res.get("gapanalysis", [])
-        gap_analysis = [GapItem(**norm_dict(item, gap_mapping)) for item in raw_gap if isinstance(item, dict)]
+        gap_analysis = [
+            GapItem(**norm_dict(item, gap_mapping))
+            for item in raw_gap
+            if isinstance(item, dict)
+        ]
 
         readiness_val = norm_res.get("readinessscore", norm_res.get("readiness", 50))
         readiness = max(0, min(100, int(readiness_val)))
 
         raw_questions = norm_res.get("questionbank", [])
-        question_bank = [QuestionItem(**norm_dict(item, q_mapping)) for item in raw_questions if isinstance(item, dict)]
+        question_bank = [
+            QuestionItem(**norm_dict(item, q_mapping))
+            for item in raw_questions
+            if isinstance(item, dict)
+        ]
 
         raw_roadmap = norm_res.get("roadmap", [])
-        roadmap = [RoadmapDay(**norm_dict(item, roadmap_mapping)) for item in raw_roadmap if isinstance(item, dict)]
+        roadmap = [
+            RoadmapDay(**norm_dict(item, roadmap_mapping))
+            for item in raw_roadmap
+            if isinstance(item, dict)
+        ]
 
         if len(roadmap) >= 1 and len(question_bank) >= 1 and len(gap_analysis) >= 1:
             return gap_analysis, readiness, question_bank, roadmap
@@ -859,12 +889,59 @@ async def generate_session_payload(
 
 def _significant_tokens(text: str) -> set[str]:
     stopwords = {
-        "the", "and", "a", "an", "of", "to", "is", "are", "in", "for", "on",
-        "with", "that", "this", "it", "as", "at", "by", "from", "be", "or",
-        "not", "have", "has", "was", "were", "will", "can", "i", "you", "your",
-        "we", "our", "they", "their", "what", "which", "when", "where", "why",
-        "how", "do", "does", "did", "so", "but", "if", "then", "because",
-        "there", "these", "those", "meaning",
+        "the",
+        "and",
+        "a",
+        "an",
+        "of",
+        "to",
+        "is",
+        "are",
+        "in",
+        "for",
+        "on",
+        "with",
+        "that",
+        "this",
+        "it",
+        "as",
+        "at",
+        "by",
+        "from",
+        "be",
+        "or",
+        "not",
+        "have",
+        "has",
+        "was",
+        "were",
+        "will",
+        "can",
+        "i",
+        "you",
+        "your",
+        "we",
+        "our",
+        "they",
+        "their",
+        "what",
+        "which",
+        "when",
+        "where",
+        "why",
+        "how",
+        "do",
+        "does",
+        "did",
+        "so",
+        "but",
+        "if",
+        "then",
+        "because",
+        "there",
+        "these",
+        "those",
+        "meaning",
     }
     return {
         token.lower()
@@ -874,11 +951,33 @@ def _significant_tokens(text: str) -> set[str]:
 
 
 FALLBACK_TECHNICAL_TERMS = {
-    "model", "data", "training", "test", "accuracy", "performance", "generalize",
-    "generalization", "variance", "bias", "overfit", "overfitting", "unseen",
-    "feature", "dataset", "classification", "regression", "optimization", "neural",
-    "network", "algorithm", "prediction", "validation", "loss", "error",
-    "regularization", "parameter",
+    "model",
+    "data",
+    "training",
+    "test",
+    "accuracy",
+    "performance",
+    "generalize",
+    "generalization",
+    "variance",
+    "bias",
+    "overfit",
+    "overfitting",
+    "unseen",
+    "feature",
+    "dataset",
+    "classification",
+    "regression",
+    "optimization",
+    "neural",
+    "network",
+    "algorithm",
+    "prediction",
+    "validation",
+    "loss",
+    "error",
+    "regularization",
+    "parameter",
 }
 
 
@@ -916,7 +1015,11 @@ async def evaluate_mock_attempt(
     answer_text = answer.strip()
     answer_words = re.findall(r"\w+", answer_text)
     # Pre-validation: Catch extremely short or purely gibberish answers early
-    if len(answer_words) < 5 or len(answer_text) < 20 or max((len(w) for w in answer_words), default=0) > 25:
+    if (
+        len(answer_words) < 5
+        or len(answer_text) < 20
+        or max((len(w) for w in answer_words), default=0) > 25
+    ):
         return 1, MockFeedback(
             strengths=["Attempted to respond"],
             missing=[
@@ -961,13 +1064,26 @@ async def evaluate_mock_attempt(
         score = max(1, min(10, int(score_val)))
 
         strengths = norm_res.get("strengths", ["Attempted to answer"])
-        missing = norm_res.get("missing", norm_res.get("areas to improve", norm_res.get("weaknesses", [])))
-        model_answer = norm_res.get("modelanswer", norm_res.get("model_answer", "Practice structured responses using STAR method."))
-        verdict = norm_res.get("onelineverdict", norm_res.get("verdict", "Basic response submitted."))
+        missing = norm_res.get(
+            "missing", norm_res.get("areas to improve", norm_res.get("weaknesses", []))
+        )
+        model_answer = norm_res.get(
+            "modelanswer",
+            norm_res.get(
+                "model_answer", "Practice structured responses using STAR method."
+            ),
+        )
+        verdict = norm_res.get(
+            "onelineverdict", norm_res.get("verdict", "Basic response submitted.")
+        )
 
         feedback = MockFeedback(
-            strengths=[str(item) for item in strengths] if isinstance(strengths, list) else [str(strengths)],
-            missing=[str(item) for item in missing] if isinstance(missing, list) else [str(missing)],
+            strengths=[str(item) for item in strengths]
+            if isinstance(strengths, list)
+            else [str(strengths)],
+            missing=[str(item) for item in missing]
+            if isinstance(missing, list)
+            else [str(missing)],
             modelAnswer=str(model_answer),
             oneLineVerdict=str(verdict),
             confidenceAnalysis=confidence,
@@ -1572,6 +1688,7 @@ def delete_job(
     db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
+
 # ---------------------------------------------------------------------------
 # Question Generation endpoint (no DB required)
 # ---------------------------------------------------------------------------
@@ -1596,7 +1713,10 @@ class GenerateQuestionResponse(BaseModel):
     question: str
 
 
-@app.post("/api/users/{user_id}/mock/generate-question", response_model=GenerateQuestionResponse)
+@app.post(
+    "/api/users/{user_id}/mock/generate-question",
+    response_model=GenerateQuestionResponse,
+)
 async def generate_mock_question(
     user_id: str,
     payload: GenerateQuestionRequest,
@@ -1737,6 +1857,7 @@ def ml_analyze_confidence(payload: ConfidenceRequest) -> ConfidenceAnalysis:
 # Mentor Chat Endpoint
 # ---------------------------------------------------------------------------
 
+
 class MentorChatRequest(BaseModel):
     conversation_id: str | None = None
     message: str
@@ -1832,7 +1953,7 @@ async def mentor_chat(
         )
         if not conv:
             raise HTTPException(status_code=404, detail="Conversation not found")
-        
+
         # Load history
         stmt = (
             select(MentorChatMessageTable)
@@ -1851,44 +1972,67 @@ async def mentor_chat(
             client=client,
             history=history,
         )
-        
+
         # Standardize response keys to handle case variations
         if isinstance(response, list) and len(response) > 0:
             response = response[0]
         if not isinstance(response, dict):
             response = {}
         norm_res = {k.lower(): v for k, v in response.items()}
-        
+
         reply_text = str(norm_res.get("reply", "")).strip()
         if not reply_text:
             raise OpenRouterError("Empty reply returned")
-            
+
         # Save messages to DB
-        db.add(MentorChatMessageTable(id=str(uuid4()), conversation_id=conv_id, role="user", content=payload.message, created_at=now))
-        db.add(MentorChatMessageTable(id=str(uuid4()), conversation_id=conv_id, role="assistant", content=reply_text, created_at=utc_now()))
-        
+        db.add(
+            MentorChatMessageTable(
+                id=str(uuid4()),
+                conversation_id=conv_id,
+                role="user",
+                content=payload.message,
+                created_at=now,
+            )
+        )
+        db.add(
+            MentorChatMessageTable(
+                id=str(uuid4()),
+                conversation_id=conv_id,
+                role="assistant",
+                content=reply_text,
+                created_at=utc_now(),
+            )
+        )
+
         # Update conversation updated_at
-        conv_to_update = db.scalar(select(MentorConversationTable).where(MentorConversationTable.id == conv_id))
+        conv_to_update = db.scalar(
+            select(MentorConversationTable).where(MentorConversationTable.id == conv_id)
+        )
         if conv_to_update:
             conv_to_update.updated_at = utc_now()
-            
+
         db.commit()
-            
+
         return MentorChatResponse(reply=reply_text, conversation_id=conv_id)
 
     except (OpenRouterError, KeyError, TypeError, ValueError) as exc:
         logger.warning("Mentor chat openrouter error: %s", exc)
         return MentorChatResponse(
             reply="I'm here to help you with your career goals, but I'm currently experiencing technical difficulties. Let's discuss your skills and readiness when I'm back online!",
-            conversation_id=conv_id or ""
+            conversation_id=conv_id or "",
         )
+
 
 class ConversationResponse(BaseModel):
     id: str
     title: str
     updated_at: str
 
-@app.get("/api/users/{user_id}/mentor-chat/conversations", response_model=list[ConversationResponse])
+
+@app.get(
+    "/api/users/{user_id}/mentor-chat/conversations",
+    response_model=list[ConversationResponse],
+)
 def get_conversations(
     user_id: str,
     _: UserTable = Depends(require_current_user),
@@ -1901,9 +2045,12 @@ def get_conversations(
     )
     convs = db.scalars(stmt).all()
     return [
-        ConversationResponse(id=c.id, title=c.title, updated_at=c.updated_at.isoformat())
+        ConversationResponse(
+            id=c.id, title=c.title, updated_at=c.updated_at.isoformat()
+        )
         for c in convs
     ]
+
 
 class ChatMessageResponse(BaseModel):
     id: str
@@ -1911,7 +2058,11 @@ class ChatMessageResponse(BaseModel):
     content: str
     created_at: str
 
-@app.get("/api/users/{user_id}/mentor-chat/conversations/{conversation_id}", response_model=list[ChatMessageResponse])
+
+@app.get(
+    "/api/users/{user_id}/mentor-chat/conversations/{conversation_id}",
+    response_model=list[ChatMessageResponse],
+)
 def get_conversation_history(
     user_id: str,
     conversation_id: str,
@@ -1926,7 +2077,7 @@ def get_conversation_history(
     )
     if not conv:
         raise HTTPException(status_code=404, detail="Conversation not found")
-        
+
     stmt = (
         select(MentorChatMessageTable)
         .where(MentorChatMessageTable.conversation_id == conversation_id)
@@ -1934,11 +2085,16 @@ def get_conversation_history(
     )
     msgs = db.scalars(stmt).all()
     return [
-        ChatMessageResponse(id=m.id, role=m.role, content=m.content, created_at=m.created_at.isoformat())
+        ChatMessageResponse(
+            id=m.id, role=m.role, content=m.content, created_at=m.created_at.isoformat()
+        )
         for m in msgs
     ]
 
-@app.delete("/api/users/{user_id}/mentor-chat/conversations/{conversation_id}", status_code=204)
+
+@app.delete(
+    "/api/users/{user_id}/mentor-chat/conversations/{conversation_id}", status_code=204
+)
 def delete_conversation(
     user_id: str,
     conversation_id: str,
@@ -1953,6 +2109,6 @@ def delete_conversation(
     )
     if not conv:
         raise HTTPException(status_code=404, detail="Conversation not found")
-        
-    db.delete(conv) # Cascades to messages due to FK
+
+    db.delete(conv)  # Cascades to messages due to FK
     db.commit()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -122,6 +122,7 @@ class UserTable(Base):
     email: Mapped[str] = mapped_column(String(255), unique=True, index=True)
     password_hash: Mapped[str] = mapped_column(String(255))
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    mentor_history_enabled: Mapped[bool] = mapped_column(Boolean, server_default="true", default=True)
 
 
 class ProfileTable(Base):
@@ -1864,6 +1865,7 @@ class MentorChatRequest(BaseModel):
     skills: list[str]
     readiness_score: float
     profile: dict[str, Any]
+    history: list[dict[str, str]] | None = None
 
 
 class MentorChatResponse(BaseModel):
@@ -1876,7 +1878,7 @@ async def mentor_chat(
     user_id: str,
     payload: MentorChatRequest,
     request: Request,
-    _: UserTable = Depends(require_current_user),
+    current_user: UserTable = Depends(require_current_user),
     db: Session = Depends(get_db),
 ) -> MentorChatResponse:
     client = getattr(request.app.state, "httpx_client", None)
@@ -1933,37 +1935,44 @@ async def mentor_chat(
         "Please provide your reply following the strict rules."
     )
 
-    history = []
+    history = payload.history or []
     conv_id = payload.conversation_id
     now = utc_now()
+    
+    is_persistent = current_user.mentor_history_enabled
 
-    if not conv_id:
-        conv_id = str(uuid4())
-        title = payload.message[:30] + ("..." if len(payload.message) > 30 else "")
-        new_conv = MentorConversationTable(
-            id=conv_id, user_id=user_id, title=title, created_at=now, updated_at=now
-        )
-        db.add(new_conv)
-    else:
-        conv = db.scalar(
-            select(MentorConversationTable).where(
-                MentorConversationTable.id == conv_id,
-                MentorConversationTable.user_id == user_id,
+    if is_persistent:
+        if not conv_id:
+            conv_id = str(uuid4())
+            title = payload.message[:30] + ("..." if len(payload.message) > 30 else "")
+            new_conv = MentorConversationTable(
+                id=conv_id, user_id=user_id, title=title, created_at=now, updated_at=now
             )
-        )
-        if not conv:
-            raise HTTPException(status_code=404, detail="Conversation not found")
-
-        # Load history
-        stmt = (
-            select(MentorChatMessageTable)
-            .where(MentorChatMessageTable.conversation_id == conv_id)
-            .order_by(MentorChatMessageTable.created_at.desc())
-            .limit(15)
-        )
-        history_records = db.scalars(stmt).all()
-        for r in reversed(history_records):
-            history.append({"role": r.role, "content": r.content})
+            db.add(new_conv)
+        else:
+            conv = db.scalar(
+                select(MentorConversationTable).where(
+                    MentorConversationTable.id == conv_id,
+                    MentorConversationTable.user_id == user_id,
+                )
+            )
+            if not conv:
+                raise HTTPException(status_code=404, detail="Conversation not found")
+    
+            # Load history
+            stmt = (
+                select(MentorChatMessageTable)
+                .where(MentorChatMessageTable.conversation_id == conv_id)
+                .order_by(MentorChatMessageTable.created_at.desc())
+                .limit(15)
+            )
+            history_records = db.scalars(stmt).all()
+            db_history = []
+            for r in reversed(history_records):
+                db_history.append({"role": r.role, "content": r.content})
+            history = db_history
+    else:
+        conv_id = ""
 
     try:
         response = await call_openrouter_json(
@@ -1984,34 +1993,35 @@ async def mentor_chat(
         if not reply_text:
             raise OpenRouterError("Empty reply returned")
 
-        # Save messages to DB
-        db.add(
-            MentorChatMessageTable(
-                id=str(uuid4()),
-                conversation_id=conv_id,
-                role="user",
-                content=payload.message,
-                created_at=now,
+        if is_persistent:
+            # Save messages to DB
+            db.add(
+                MentorChatMessageTable(
+                    id=str(uuid4()),
+                    conversation_id=conv_id,
+                    role="user",
+                    content=payload.message,
+                    created_at=now,
+                )
             )
-        )
-        db.add(
-            MentorChatMessageTable(
-                id=str(uuid4()),
-                conversation_id=conv_id,
-                role="assistant",
-                content=reply_text,
-                created_at=utc_now(),
+            db.add(
+                MentorChatMessageTable(
+                    id=str(uuid4()),
+                    conversation_id=conv_id,
+                    role="assistant",
+                    content=reply_text,
+                    created_at=utc_now(),
+                )
             )
-        )
-
-        # Update conversation updated_at
-        conv_to_update = db.scalar(
-            select(MentorConversationTable).where(MentorConversationTable.id == conv_id)
-        )
-        if conv_to_update:
-            conv_to_update.updated_at = utc_now()
-
-        db.commit()
+    
+            # Update conversation updated_at
+            conv_to_update = db.scalar(
+                select(MentorConversationTable).where(MentorConversationTable.id == conv_id)
+            )
+            if conv_to_update:
+                conv_to_update.updated_at = utc_now()
+    
+            db.commit()
 
         return MentorChatResponse(reply=reply_text, conversation_id=conv_id)
 
@@ -2028,6 +2038,34 @@ class ConversationResponse(BaseModel):
     title: str
     updated_at: str
 
+class MentorSettingsResponse(BaseModel):
+    mentor_history_enabled: bool
+
+class MentorSettingsUpdateRequest(BaseModel):
+    mentor_history_enabled: bool
+
+@app.get("/api/users/{user_id}/mentor-chat/settings", response_model=MentorSettingsResponse)
+def get_mentor_settings(
+    user_id: str,
+    current_user: UserTable = Depends(require_current_user),
+) -> MentorSettingsResponse:
+    if current_user.id != user_id:
+        raise HTTPException(status_code=403, detail="Forbidden")
+    return MentorSettingsResponse(mentor_history_enabled=current_user.mentor_history_enabled)
+
+@app.patch("/api/users/{user_id}/mentor-chat/settings", response_model=MentorSettingsResponse)
+def update_mentor_settings(
+    user_id: str,
+    payload: MentorSettingsUpdateRequest,
+    current_user: UserTable = Depends(require_current_user),
+    db: Session = Depends(get_db),
+) -> MentorSettingsResponse:
+    if current_user.id != user_id:
+        raise HTTPException(status_code=403, detail="Forbidden")
+    
+    current_user.mentor_history_enabled = payload.mentor_history_enabled
+    db.commit()
+    return MentorSettingsResponse(mentor_history_enabled=current_user.mentor_history_enabled)
 
 @app.get(
     "/api/users/{user_id}/mentor-chat/conversations",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,11 @@ import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Any, Literal
 from uuid import uuid4
+# pyrefly: ignore [missing-import]
+from dotenv import load_dotenv
+from pathlib import Path
+
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 
 import httpx
 from fastapi import (
@@ -37,6 +42,7 @@ from sqlalchemy import (
     delete,
     func,
     select,
+    ForeignKey,
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, sessionmaker
 
@@ -97,6 +103,14 @@ SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, futu
 
 class Base(DeclarativeBase):
     pass
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def today_iso() -> str:
+    return utc_now().date().isoformat()
 
 
 class UserTable(Base):
@@ -186,12 +200,24 @@ class JobApplicationTable(Base):
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
 
-def utc_now() -> datetime:
-    return datetime.now(timezone.utc)
+class MentorConversationTable(Base):
+    __tablename__ = "mentor_conversations"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    user_id: Mapped[str] = mapped_column(String(36), index=True)
+    title: Mapped[str] = mapped_column(String(255))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
 
 
-def today_iso() -> str:
-    return utc_now().date().isoformat()
+class MentorChatMessageTable(Base):
+    __tablename__ = "mentor_chat_messages"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    conversation_id: Mapped[str] = mapped_column(String(36), ForeignKey("mentor_conversations.id", ondelete="CASCADE"), index=True)
+    role: Mapped[str] = mapped_column(String(20)) # "user" or "assistant"
+    content: Mapped[str] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now)
 
 
 def get_db() -> Session:
@@ -530,7 +556,7 @@ def stable_number(seed: str, minimum: int, maximum: int) -> int:
 
 
 async def call_openrouter_json(
-    system_prompt: str, user_prompt: str, client: httpx.AsyncClient | None = None
+    system_prompt: str, user_prompt: str, client: httpx.AsyncClient | None = None, history: list[dict[str, str]] | None = None
 ) -> dict[str, Any]:
     if GEMINI_API_KEY:
         url = "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
@@ -553,13 +579,15 @@ async def call_openrouter_json(
         }
         provider_name = "OpenRouter"
 
+    messages = [{"role": "system", "content": system_prompt}]
+    if history:
+        messages.extend(history)
+    messages.append({"role": "user", "content": user_prompt})
+
     payload = {
         "model": model,
         "response_format": {"type": "json_object"},
-        "messages": [
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_prompt},
-        ],
+        "messages": messages,
     }
 
     max_retries = 3
@@ -1703,3 +1731,228 @@ def ml_match_score(payload: MatchScoreRequest) -> MatchScoreResponse:
 def ml_analyze_confidence(payload: ConfidenceRequest) -> ConfidenceAnalysis:
     result = analyze_confidence(payload.text)
     return ConfidenceAnalysis(**result)
+
+
+# ---------------------------------------------------------------------------
+# Mentor Chat Endpoint
+# ---------------------------------------------------------------------------
+
+class MentorChatRequest(BaseModel):
+    conversation_id: str | None = None
+    message: str
+    skills: list[str]
+    readiness_score: float
+    profile: dict[str, Any]
+
+
+class MentorChatResponse(BaseModel):
+    reply: str
+    conversation_id: str
+
+
+@app.post("/api/users/{user_id}/mentor-chat", response_model=MentorChatResponse)
+async def mentor_chat(
+    user_id: str,
+    payload: MentorChatRequest,
+    request: Request,
+    _: UserTable = Depends(require_current_user),
+    db: Session = Depends(get_db),
+) -> MentorChatResponse:
+    client = getattr(request.app.state, "httpx_client", None)
+
+    profile_str = json.dumps(payload.profile) if payload.profile else "Not provided"
+    skills_str = ", ".join(payload.skills) if payload.skills else "Not provided"
+
+    system_prompt = (
+        "You are PrepIQ AI Mentor, a smart AI career coach focused on software engineering careers, internships, placements, interview preparation, and technical skill growth.\n\n"
+        "Your personality:\n"
+        "- conversational like ChatGPT/Claude\n"
+        "- casual but intelligent\n"
+        "- supportive but realistic\n"
+        "- practical, not motivational fluff\n"
+        "- specific and domain-aware\n"
+        "- clear and actionable\n\n"
+        "You specialize in:\n"
+        "- software engineering careers\n"
+        "- backend/frontend/fullstack guidance\n"
+        "- AI/ML career guidance\n"
+        "- DSA preparation\n"
+        "- interview readiness analysis\n"
+        "- mock interview feedback\n"
+        "- resume improvement\n"
+        "- job application strategy\n"
+        "- internship roadmaps\n"
+        "- skill prioritization\n"
+        "- realistic career planning\n\n"
+        "Strict rules:\n"
+        "- NEVER hallucinate user details\n"
+        "- NEVER invent skills, work experience, companies, projects, or education\n"
+        "- ONLY use actual PrepIQ user context\n"
+        "- if information is missing, ask natural follow-up questions instead of guessing\n"
+        "- never give generic canned responses\n"
+        "- responses must feel personalized and contextual\n\n"
+        "Response style:\n"
+        "- sound human and natural\n"
+        "- explain reasoning clearly\n"
+        "- compare options when useful\n"
+        "- break advice into actionable steps\n"
+        "- be honest about weaknesses and gaps\n"
+        "- provide timelines when relevant\n\n"
+        "Return valid JSON only. Do not include markdown or explanations outside the JSON.\n"
+        'Use exactly this schema: {"reply": "string"}. '
+    )
+
+    user_prompt = (
+        f"--- USER CONTEXT ---\n"
+        f"Readiness Score: {payload.readiness_score}\n"
+        f"Skills: {skills_str}\n"
+        f"Profile Data (including prep context, mock performance, and job tracker): {profile_str}\n"
+        f"--------------------\n\n"
+        f"User Message: {payload.message}\n\n"
+        "Please provide your reply following the strict rules."
+    )
+
+    history = []
+    conv_id = payload.conversation_id
+    now = utc_now()
+
+    if not conv_id:
+        conv_id = str(uuid4())
+        title = payload.message[:30] + ("..." if len(payload.message) > 30 else "")
+        new_conv = MentorConversationTable(
+            id=conv_id, user_id=user_id, title=title, created_at=now, updated_at=now
+        )
+        db.add(new_conv)
+    else:
+        conv = db.scalar(
+            select(MentorConversationTable).where(
+                MentorConversationTable.id == conv_id,
+                MentorConversationTable.user_id == user_id,
+            )
+        )
+        if not conv:
+            raise HTTPException(status_code=404, detail="Conversation not found")
+        
+        # Load history
+        stmt = (
+            select(MentorChatMessageTable)
+            .where(MentorChatMessageTable.conversation_id == conv_id)
+            .order_by(MentorChatMessageTable.created_at.desc())
+            .limit(15)
+        )
+        history_records = db.scalars(stmt).all()
+        for r in reversed(history_records):
+            history.append({"role": r.role, "content": r.content})
+
+    try:
+        response = await call_openrouter_json(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            client=client,
+            history=history,
+        )
+        
+        # Standardize response keys to handle case variations
+        if isinstance(response, list) and len(response) > 0:
+            response = response[0]
+        if not isinstance(response, dict):
+            response = {}
+        norm_res = {k.lower(): v for k, v in response.items()}
+        
+        reply_text = str(norm_res.get("reply", "")).strip()
+        if not reply_text:
+            raise OpenRouterError("Empty reply returned")
+            
+        # Save messages to DB
+        db.add(MentorChatMessageTable(id=str(uuid4()), conversation_id=conv_id, role="user", content=payload.message, created_at=now))
+        db.add(MentorChatMessageTable(id=str(uuid4()), conversation_id=conv_id, role="assistant", content=reply_text, created_at=utc_now()))
+        
+        # Update conversation updated_at
+        conv_to_update = db.scalar(select(MentorConversationTable).where(MentorConversationTable.id == conv_id))
+        if conv_to_update:
+            conv_to_update.updated_at = utc_now()
+            
+        db.commit()
+            
+        return MentorChatResponse(reply=reply_text, conversation_id=conv_id)
+
+    except (OpenRouterError, KeyError, TypeError, ValueError) as exc:
+        logger.warning("Mentor chat openrouter error: %s", exc)
+        return MentorChatResponse(
+            reply="I'm here to help you with your career goals, but I'm currently experiencing technical difficulties. Let's discuss your skills and readiness when I'm back online!",
+            conversation_id=conv_id or ""
+        )
+
+class ConversationResponse(BaseModel):
+    id: str
+    title: str
+    updated_at: str
+
+@app.get("/api/users/{user_id}/mentor-chat/conversations", response_model=list[ConversationResponse])
+def get_conversations(
+    user_id: str,
+    _: UserTable = Depends(require_current_user),
+    db: Session = Depends(get_db),
+) -> list[ConversationResponse]:
+    stmt = (
+        select(MentorConversationTable)
+        .where(MentorConversationTable.user_id == user_id)
+        .order_by(MentorConversationTable.updated_at.desc())
+    )
+    convs = db.scalars(stmt).all()
+    return [
+        ConversationResponse(id=c.id, title=c.title, updated_at=c.updated_at.isoformat())
+        for c in convs
+    ]
+
+class ChatMessageResponse(BaseModel):
+    id: str
+    role: str
+    content: str
+    created_at: str
+
+@app.get("/api/users/{user_id}/mentor-chat/conversations/{conversation_id}", response_model=list[ChatMessageResponse])
+def get_conversation_history(
+    user_id: str,
+    conversation_id: str,
+    _: UserTable = Depends(require_current_user),
+    db: Session = Depends(get_db),
+) -> list[ChatMessageResponse]:
+    conv = db.scalar(
+        select(MentorConversationTable).where(
+            MentorConversationTable.id == conversation_id,
+            MentorConversationTable.user_id == user_id,
+        )
+    )
+    if not conv:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+        
+    stmt = (
+        select(MentorChatMessageTable)
+        .where(MentorChatMessageTable.conversation_id == conversation_id)
+        .order_by(MentorChatMessageTable.created_at.asc())
+    )
+    msgs = db.scalars(stmt).all()
+    return [
+        ChatMessageResponse(id=m.id, role=m.role, content=m.content, created_at=m.created_at.isoformat())
+        for m in msgs
+    ]
+
+@app.delete("/api/users/{user_id}/mentor-chat/conversations/{conversation_id}", status_code=204)
+def delete_conversation(
+    user_id: str,
+    conversation_id: str,
+    _: UserTable = Depends(require_current_user),
+    db: Session = Depends(get_db),
+):
+    conv = db.scalar(
+        select(MentorConversationTable).where(
+            MentorConversationTable.id == conversation_id,
+            MentorConversationTable.user_id == user_id,
+        )
+    )
+    if not conv:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+        
+    db.delete(conv) # Cascades to messages due to FK
+    db.commit()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1311,9 +1311,7 @@ def signup(payload: SignupRequest, db: Session = Depends(get_db)) -> AuthRespons
 
 
 @app.get("/api/auth/me", response_model=User)
-def me(
-    current_user: UserTable = Depends(require_current_user)
-) -> User:
+def me(current_user: UserTable = Depends(require_current_user)) -> User:
     return user_from_table(current_user)
 
 
@@ -1432,7 +1430,13 @@ async def create_session(
     db: Session = Depends(get_db),
 ) -> InterviewSession:
     client = getattr(request.app.state, "httpx_client", None)
-    gap_analysis, readiness, question_bank, roadmap, is_estimated = await generate_session_payload(
+    (
+        gap_analysis,
+        readiness,
+        question_bank,
+        roadmap,
+        is_estimated,
+    ) = await generate_session_payload(
         payload.jobTitle,
         payload.company,
         payload.jdText,
@@ -1856,7 +1860,7 @@ def ml_match_score(payload: MatchScoreRequest) -> MatchScoreResponse:
         overallScore=scores["overallScore"],
         semanticScore=scores["semanticScore"],
         keywordOverlapScore=scores["keywordOverlapScore"],
-        label=label
+        label=label,
     )
 
 

--- a/backend/app/ml.py
+++ b/backend/app/ml.py
@@ -53,13 +53,20 @@ def _get_sentence_transformer():
     if _sentence_transformer_model is None:
         try:
             from sentence_transformers import SentenceTransformer
+
             # Load the lightweight, fast model recommended in the issue
-            _sentence_transformer_model = SentenceTransformer('all-MiniLM-L6-v2')
-            logger.info("sentence-transformers model 'all-MiniLM-L6-v2' loaded successfully")
+            _sentence_transformer_model = SentenceTransformer("all-MiniLM-L6-v2")
+            logger.info(
+                "sentence-transformers model 'all-MiniLM-L6-v2' loaded successfully"
+            )
         except Exception as exc:
             logger.warning("Failed to load sentence-transformers model: %s", exc)
             _sentence_transformer_model = False
-    return _sentence_transformer_model if _sentence_transformer_model is not False else None
+    return (
+        _sentence_transformer_model
+        if _sentence_transformer_model is not False
+        else None
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -277,6 +284,7 @@ def extract_skills(text: str) -> list[str]:
 # Feature 2: Resume ↔ JD Match Score
 # ---------------------------------------------------------------------------
 
+
 def compute_match_score(resume_text: str, jd_text: str) -> dict[str, int]:
     """
     Compute similarity between resume and job description using semantic embeddings
@@ -329,7 +337,7 @@ def compute_match_score(resume_text: str, jd_text: str) -> dict[str, int]:
     return {
         "semanticScore": semantic_score,
         "keywordOverlapScore": keyword_score,
-        "overallScore": overall_score
+        "overallScore": overall_score,
     }
 
 

--- a/backend/app/ml.py
+++ b/backend/app/ml.py
@@ -32,10 +32,13 @@ def _get_spacy():
         if "nlp" not in _spacy_cache:
             try:
                 import spacy
+
                 _spacy_cache["nlp"] = spacy.load("en_core_web_sm")
                 logger.info("spaCy model loaded successfully")
             except OSError:
-                logger.warning("spaCy model 'en_core_web_sm' not found. Run: python -m spacy download en_core_web_sm")
+                logger.warning(
+                    "spaCy model 'en_core_web_sm' not found. Run: python -m spacy download en_core_web_sm"
+                )
                 _spacy_cache["nlp"] = None
     return _spacy_cache["nlp"]
 
@@ -46,49 +49,162 @@ def _get_spacy():
 
 TECH_SKILLS = {
     # Programming Languages
-    "python", "javascript", "typescript", "java", "c++", "c#", "go", "golang",
-    "rust", "ruby", "php", "swift", "kotlin", "scala", "r", "matlab", "perl",
-    "dart", "lua", "haskell", "elixir", "clojure",
-
+    "python",
+    "javascript",
+    "typescript",
+    "java",
+    "c++",
+    "c#",
+    "go",
+    "golang",
+    "rust",
+    "ruby",
+    "php",
+    "swift",
+    "kotlin",
+    "scala",
+    "r",
+    "matlab",
+    "perl",
+    "dart",
+    "lua",
+    "haskell",
+    "elixir",
+    "clojure",
     # Frontend
-    "react", "reactjs", "react.js", "angular", "vue", "vuejs", "vue.js",
-    "next.js", "nextjs", "nuxt", "svelte", "html", "css", "sass", "scss",
-    "tailwind", "tailwindcss", "bootstrap", "jquery", "webpack", "vite",
-    "redux", "zustand", "framer motion",
-
+    "react",
+    "reactjs",
+    "react.js",
+    "angular",
+    "vue",
+    "vuejs",
+    "vue.js",
+    "next.js",
+    "nextjs",
+    "nuxt",
+    "svelte",
+    "html",
+    "css",
+    "sass",
+    "scss",
+    "tailwind",
+    "tailwindcss",
+    "bootstrap",
+    "jquery",
+    "webpack",
+    "vite",
+    "redux",
+    "zustand",
+    "framer motion",
     # Backend
-    "node", "nodejs", "node.js", "express", "expressjs", "fastapi", "flask",
-    "django", "spring", "spring boot", "laravel", "rails", "ruby on rails",
-    "asp.net", "gin", "fiber", "nestjs",
-
+    "node",
+    "nodejs",
+    "node.js",
+    "express",
+    "expressjs",
+    "fastapi",
+    "flask",
+    "django",
+    "spring",
+    "spring boot",
+    "laravel",
+    "rails",
+    "ruby on rails",
+    "asp.net",
+    "gin",
+    "fiber",
+    "nestjs",
     # Databases
-    "sql", "mysql", "postgresql", "postgres", "mongodb", "redis", "sqlite",
-    "dynamodb", "cassandra", "elasticsearch", "neo4j", "firebase", "supabase",
-    "prisma", "sequelize", "sqlalchemy", "mongoose",
-
+    "sql",
+    "mysql",
+    "postgresql",
+    "postgres",
+    "mongodb",
+    "redis",
+    "sqlite",
+    "dynamodb",
+    "cassandra",
+    "elasticsearch",
+    "neo4j",
+    "firebase",
+    "supabase",
+    "prisma",
+    "sequelize",
+    "sqlalchemy",
+    "mongoose",
     # Cloud & DevOps
-    "aws", "azure", "gcp", "google cloud", "docker", "kubernetes", "k8s",
-    "terraform", "ansible", "jenkins", "ci/cd", "github actions", "gitlab ci",
-    "nginx", "apache", "linux", "bash", "shell scripting",
-
+    "aws",
+    "azure",
+    "gcp",
+    "google cloud",
+    "docker",
+    "kubernetes",
+    "k8s",
+    "terraform",
+    "ansible",
+    "jenkins",
+    "ci/cd",
+    "github actions",
+    "gitlab ci",
+    "nginx",
+    "apache",
+    "linux",
+    "bash",
+    "shell scripting",
     # AI/ML
-    "machine learning", "deep learning", "tensorflow", "pytorch", "keras",
-    "scikit-learn", "sklearn", "pandas", "numpy", "opencv", "nlp",
-    "natural language processing", "computer vision", "transformers",
-    "hugging face", "langchain", "openai", "llm",
-
+    "machine learning",
+    "deep learning",
+    "tensorflow",
+    "pytorch",
+    "keras",
+    "scikit-learn",
+    "sklearn",
+    "pandas",
+    "numpy",
+    "opencv",
+    "nlp",
+    "natural language processing",
+    "computer vision",
+    "transformers",
+    "hugging face",
+    "langchain",
+    "openai",
+    "llm",
     # Tools & Misc
-    "git", "github", "gitlab", "bitbucket", "jira", "confluence",
-    "figma", "postman", "swagger", "graphql", "rest", "restful",
-    "api", "microservices", "agile", "scrum", "kanban",
-    "testing", "jest", "pytest", "unittest", "cypress", "selenium",
-    "oauth", "jwt", "websockets", "grpc",
+    "git",
+    "github",
+    "gitlab",
+    "bitbucket",
+    "jira",
+    "confluence",
+    "figma",
+    "postman",
+    "swagger",
+    "graphql",
+    "rest",
+    "restful",
+    "api",
+    "microservices",
+    "agile",
+    "scrum",
+    "kanban",
+    "testing",
+    "jest",
+    "pytest",
+    "unittest",
+    "cypress",
+    "selenium",
+    "oauth",
+    "jwt",
+    "websockets",
+    "grpc",
 }
 
 
 # ---------------------------------------------------------------------------
 # Feature 1: Resume Skill Extraction
 # ---------------------------------------------------------------------------
+
 
 def extract_skills(text: str) -> list[str]:
     """
@@ -102,27 +218,23 @@ def extract_skills(text: str) -> list[str]:
     found_skills: set[str] = set()
     text_lower = text.lower()
     # Normalize separators and spacing for multi-word skill matching
-    normalized_text = re.sub(r'[-_/]', ' ', text_lower)
-    normalized_text = re.sub(r'\s+', ' ', normalized_text).strip()
-
+    normalized_text = re.sub(r"[-_/]", " ", text_lower)
+    normalized_text = re.sub(r"\s+", " ", normalized_text).strip()
 
     # Method 1: Keyword matching against curated skill list
     for skill in sorted(TECH_SKILLS, key=len, reverse=True):
         # Multi-word skills need safer boundary handling
-        if ' ' in skill:
-            pattern = r'(?<!\w)' + re.escape(skill) + r'(?!\w)'
+        if " " in skill:
+            pattern = r"(?<!\w)" + re.escape(skill) + r"(?!\w)"
         else:
-            pattern = r'\b' + re.escape(skill) + r'\b'
+            pattern = r"\b" + re.escape(skill) + r"\b"
 
         if re.search(pattern, normalized_text):
-
             # Avoid adding shorter overlapping skills
             if any(skill in existing.lower() for existing in found_skills):
                 continue
 
-            found_skills.add(
-                skill.title() if len(skill) > 3 else skill.upper()
-            )
+            found_skills.add(skill.title() if len(skill) > 3 else skill.upper())
 
     # Method 2: spaCy NER to catch additional entities
     nlp = _get_spacy()
@@ -145,6 +257,7 @@ def extract_skills(text: str) -> list[str]:
 # ---------------------------------------------------------------------------
 # Feature 2: Resume ↔ JD Match Score
 # ---------------------------------------------------------------------------
+
 
 def compute_match_score(resume_text: str, jd_text: str) -> int:
     """
@@ -185,6 +298,7 @@ def compute_match_score(resume_text: str, jd_text: str) -> int:
 # Feature 3: Answer Confidence Analysis
 # ---------------------------------------------------------------------------
 
+
 def analyze_confidence(answer_text: str) -> dict[str, Any]:
     """
     Analyze the confidence and quality of a mock interview answer
@@ -206,7 +320,7 @@ def analyze_confidence(answer_text: str) -> dict[str, Any]:
 
     words = answer_text.split()
     word_count = len(words)
-    sentences = [s.strip() for s in re.split(r'[.!?]+', answer_text) if s.strip()]
+    sentences = [s.strip() for s in re.split(r"[.!?]+", answer_text) if s.strip()]
     sentence_count = max(1, len(sentences))
 
     # --- Sentiment analysis with TextBlob ---
@@ -216,7 +330,7 @@ def analyze_confidence(answer_text: str) -> dict[str, Any]:
         from textblob import TextBlob
 
         blob = TextBlob(answer_text)
-        polarity = blob.sentiment.polarity        # -1.0 to 1.0
+        polarity = blob.sentiment.polarity  # -1.0 to 1.0
 
     except Exception as exc:
         logger.warning("TextBlob sentiment analysis failed: %s", exc)
@@ -230,10 +344,25 @@ def analyze_confidence(answer_text: str) -> dict[str, Any]:
         sentiment = "neutral"
 
     # More numbers, percentages, and concrete metrics = more specific
-    number_count = len(re.findall(r'\b\d+[\d,.]*%?\b', answer_text))
-    metric_keywords = ["increased", "decreased", "improved", "reduced", "achieved",
-                       "delivered", "built", "managed", "led", "saved", "generated",
-                       "revenue", "users", "clients", "team", "project"]
+    number_count = len(re.findall(r"\b\d+[\d,.]*%?\b", answer_text))
+    metric_keywords = [
+        "increased",
+        "decreased",
+        "improved",
+        "reduced",
+        "achieved",
+        "delivered",
+        "built",
+        "managed",
+        "led",
+        "saved",
+        "generated",
+        "revenue",
+        "users",
+        "clients",
+        "team",
+        "project",
+    ]
     metric_hits = sum(1 for kw in metric_keywords if kw in answer_text.lower())
 
     specificity_raw = (number_count * 15) + (metric_hits * 8)
@@ -241,12 +370,14 @@ def analyze_confidence(answer_text: str) -> dict[str, Any]:
 
     # --- Confidence score ---
     # Composite of: sentiment, length, specificity, sentence structure
-    length_score = min(40, word_count * 0.2)           # Up to 40 pts for length (200+ words)
-    sentiment_score = max(0, (polarity + 1) * 15)      # Up to 30 pts for positive tone
-    specificity_score = specificity * 0.2               # Up to 20 pts for specifics
-    structure_score = min(10, sentence_count * 2)       # Up to 10 pts for multi-sentence
+    length_score = min(40, word_count * 0.2)  # Up to 40 pts for length (200+ words)
+    sentiment_score = max(0, (polarity + 1) * 15)  # Up to 30 pts for positive tone
+    specificity_score = specificity * 0.2  # Up to 20 pts for specifics
+    structure_score = min(10, sentence_count * 2)  # Up to 10 pts for multi-sentence
 
-    confidence_score = int(min(100, length_score + sentiment_score + specificity_score + structure_score))
+    confidence_score = int(
+        min(100, length_score + sentiment_score + specificity_score + structure_score)
+    )
 
     return {
         "confidenceScore": confidence_score,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ pdfplumber
 python-docx
 python-multipart
 sentence-transformers
+python-dotenv>=1.0.0

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -404,7 +404,9 @@ class PrepIQApiTestCase(unittest.TestCase):
         self.assertEqual(res_empty_job.status_code, 422)
         payload_job = res_empty_job.json()
         self.assertEqual(payload_job["detail"][0]["loc"], ["body", "jobTitle"])
-        self.assertIn("cannot be empty or whitespace-only", payload_job["detail"][0]["msg"])
+        self.assertIn(
+            "cannot be empty or whitespace-only", payload_job["detail"][0]["msg"]
+        )
 
         res_empty_company = self.client.post(
             f"/api/users/{user_id}/sessions",
@@ -419,7 +421,9 @@ class PrepIQApiTestCase(unittest.TestCase):
         self.assertEqual(res_empty_company.status_code, 422)
         payload_company = res_empty_company.json()
         self.assertEqual(payload_company["detail"][0]["loc"], ["body", "company"])
-        self.assertIn("cannot be empty or whitespace-only", payload_company["detail"][0]["msg"])
+        self.assertIn(
+            "cannot be empty or whitespace-only", payload_company["detail"][0]["msg"]
+        )
 
     def test_generate_question_endpoint(self) -> None:
         user_id, headers = self.create_account()

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,6 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -132,7 +131,6 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -163,6 +161,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -3075,8 +3074,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3179,6 +3177,7 @@
       "integrity": "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3209,6 +3208,7 @@
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3220,6 +3220,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3277,6 +3278,7 @@
       "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.38.0",
         "@typescript-eslint/types": "8.38.0",
@@ -3632,6 +3634,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3910,6 +3913,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -4398,6 +4402,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -4494,8 +4499,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -4563,7 +4567,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -4752,6 +4757,7 @@
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5666,6 +5672,7 @@
       "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "abab": "^2.0.6",
         "acorn": "^8.8.1",
@@ -5732,6 +5739,7 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
       "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "fast-png": "^6.2.0",
@@ -5875,7 +5883,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6351,6 +6358,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6491,7 +6499,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6507,7 +6514,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6518,7 +6524,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6531,8 +6536,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6616,6 +6620,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6642,6 +6647,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6655,6 +6661,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.61.1.tgz",
       "integrity": "sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -7367,6 +7374,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -7500,6 +7508,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7622,6 +7631,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7832,6 +7842,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ const InterviewPrepPage = lazy(() => import("./pages/InterviewPrepPage"));
 const MockInterviewPage = lazy(() => import("./pages/MockInterviewPage"));
 const JobTrackerPage = lazy(() => import("./pages/JobTrackerPage"));
 const ProgressPage = lazy(() => import("./pages/ProgressPage"));
+const MentorChatPage = lazy(() => import("./pages/MentorChatPage"));
 
 const queryClient = new QueryClient();
 
@@ -126,6 +127,7 @@ function AppRoutes() {
         <Route path="/mock-interview" element={<ProtectedRoute hydrated={hydrated} user={user} logout={logout} resourceErrorMessage={resourceErrorMessage}><MockInterviewPage sessions={sessions} attempts={attempts} onAddAttempt={addAttempt} userId={user?.id || ""} /></ProtectedRoute>} />
         <Route path="/job-tracker" element={<ProtectedRoute hydrated={hydrated} user={user} logout={logout} resourceErrorMessage={resourceErrorMessage}><JobTrackerPage jobs={jobs} sessions={sessions} onAddJob={addJob} onUpdateJob={updateJob} onDeleteJob={deleteJob} userId={user?.id || ""} /></ProtectedRoute>} />
         <Route path="/progress" element={<ProtectedRoute hydrated={hydrated} user={user} logout={logout} resourceErrorMessage={resourceErrorMessage}><ProgressPage mocks={attempts} sessions={sessions} /></ProtectedRoute>} />
+        <Route path="/mentor-chat" element={<ProtectedRoute hydrated={hydrated} user={user} logout={logout} resourceErrorMessage={resourceErrorMessage}><MentorChatPage user={user!} profile={profile} sessions={sessions} mocks={attempts} jobs={jobs} /></ProtectedRoute>} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </Suspense>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -10,6 +10,7 @@ import {
   Sun,
   Moon,
   SunMoon,
+  Bot,
 } from "lucide-react";
 import { useTheme } from "next-themes";
 import { NavLink } from "@/components/NavLink";
@@ -32,6 +33,7 @@ const navItems = [
   { title: "Interview Prep", url: "/interview-prep", icon: BookOpen },
   { title: "Mock Interview", url: "/mock-interview", icon: MessageSquare },
   { title: "Job Tracker", url: "/job-tracker", icon: Briefcase },
+  { title: "AI Mentor Chat", url: "/mentor-chat", icon: Bot },
   { title: "Progress", url: "/progress", icon: TrendingUp },
 ];
 

--- a/src/components/mentor/CyberBackground.tsx
+++ b/src/components/mentor/CyberBackground.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useRef } from "react";
+
+export function CyberBackground() {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    // Check if it's a touch device; if so, we can disable the animation to save battery
+    if (window.matchMedia("(hover: none)").matches) {
+      return;
+    }
+
+    let rafId: number;
+    let targetX = window.innerWidth / 2;
+    let targetY = window.innerHeight / 2;
+    let currentX = targetX;
+    let currentY = targetY;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const rect = container.getBoundingClientRect();
+      targetX = e.clientX - rect.left;
+      targetY = e.clientY - rect.top;
+    };
+
+    const animate = () => {
+      currentX += (targetX - currentX) * 0.15;
+      currentY += (targetY - currentY) * 0.15;
+      
+      container.style.setProperty("--mouse-x", `${currentX}px`);
+      container.style.setProperty("--mouse-y", `${currentY}px`);
+      
+      rafId = requestAnimationFrame(animate);
+    };
+
+    window.addEventListener("mousemove", handleMouseMove, { passive: true });
+    rafId = requestAnimationFrame(animate);
+
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      cancelAnimationFrame(rafId);
+    };
+  }, []);
+
+  return (
+    <div 
+      ref={containerRef}
+      className="absolute inset-0 z-0 overflow-hidden bg-[#03030a] pointer-events-none rounded-xl"
+    >
+      {/* Ambient static glow for mobile fallback and baseline aesthetics */}
+      <div className="absolute top-[-20%] left-[-10%] w-[50%] h-[50%] rounded-full bg-purple-900/10 blur-[120px]" />
+      <div className="absolute bottom-[-20%] right-[-10%] w-[50%] h-[50%] rounded-full bg-blue-900/10 blur-[120px]" />
+
+      {/* The Dynamic Cursor Glow (Desktop Only) */}
+      <div 
+        className="absolute top-0 left-0 w-[800px] h-[800px] rounded-full mix-blend-screen hidden sm:block opacity-60"
+        style={{
+          transform: "translate(calc(var(--mouse-x, 50vw) - 400px), calc(var(--mouse-y, 50vh) - 400px))",
+          background: "radial-gradient(circle, rgba(147, 51, 234, 0.15) 0%, rgba(59, 130, 246, 0.05) 40%, transparent 70%)",
+          willChange: "transform"
+        }}
+      />
+      
+      {/* The + Grid Pattern with dynamic masking */}
+      <div 
+        className="absolute inset-0 opacity-40 sm:opacity-70"
+        style={{
+          backgroundImage: `url("data:image/svg+xml,%3Csvg width='40' height='40' viewBox='0 0 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M20 17v6m-3-3h6' stroke='rgba(255,255,255,0.3)' stroke-width='1.5' stroke-linecap='round' fill='none'/%3E%3C/svg%3E")`,
+          backgroundSize: "40px 40px",
+          maskImage: "radial-gradient(circle 400px at var(--mouse-x, 50vw) var(--mouse-y, 50vh), black 10%, transparent 100%)",
+          WebkitMaskImage: "radial-gradient(circle 400px at var(--mouse-x, 50vw) var(--mouse-y, 50vh), black 10%, transparent 100%)"
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/mentor/MentorSidebar.tsx
+++ b/src/components/mentor/MentorSidebar.tsx
@@ -1,0 +1,235 @@
+import { useState, useMemo } from "react";
+import { Plus, MessageSquare, Trash2, X, Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { isToday, isYesterday, isThisWeek, parseISO } from "date-fns";
+import { motion, AnimatePresence } from "framer-motion";
+
+export interface Conversation {
+  id: string;
+  title: string;
+  updated_at: string;
+}
+
+interface MentorSidebarProps {
+  conversations: Conversation[];
+  activeConversationId: string | null;
+  isMobileMenuOpen: boolean;
+  isDesktopCollapsed: boolean;
+  onSelectConversation: (id: string) => void;
+  onDeleteConversation: (e: React.MouseEvent, id: string) => void;
+  onNewChat: () => void;
+  onCloseMobileSidebar: () => void;
+  onToggleCollapse: () => void;
+}
+
+export function MentorSidebar({
+  conversations,
+  activeConversationId,
+  isMobileMenuOpen,
+  isDesktopCollapsed,
+  onSelectConversation,
+  onDeleteConversation,
+  onNewChat,
+  onCloseMobileSidebar,
+  onToggleCollapse
+}: MentorSidebarProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const filteredConversations = useMemo(() => {
+    if (!searchQuery.trim()) return conversations;
+    const lowerQuery = searchQuery.toLowerCase();
+    return conversations.filter(c => c.title.toLowerCase().includes(lowerQuery));
+  }, [conversations, searchQuery]);
+
+  const grouped = useMemo(() => {
+    const groups: Record<string, Conversation[]> = {
+      Today: [],
+      Yesterday: [],
+      "This Week": [],
+      Older: []
+    };
+
+    filteredConversations.forEach(conv => {
+      const date = parseISO(conv.updated_at);
+      if (isToday(date)) groups.Today.push(conv);
+      else if (isYesterday(date)) groups.Yesterday.push(conv);
+      else if (isThisWeek(date)) groups["This Week"].push(conv);
+      else groups.Older.push(conv);
+    });
+
+    return groups;
+  }, [filteredConversations]);
+
+  return (
+    <>
+      {/* Mobile Overlay */}
+      {isMobileMenuOpen && (
+        <div 
+          className="absolute inset-0 bg-black/60 backdrop-blur-sm z-20 md:hidden transition-opacity"
+          onClick={onCloseMobileSidebar}
+        />
+      )}
+
+      {/* Main Sidebar */}
+      <motion.div 
+        animate={{ 
+          width: isDesktopCollapsed ? 72 : 300,
+        }}
+        transition={{ duration: 0.3, ease: [0.4, 0.0, 0.2, 1] }}
+        className={`
+          absolute md:relative z-30
+          h-full flex flex-col shrink-0
+          bg-black/40 backdrop-blur-2xl border-r border-white/10 shadow-2xl
+          transition-transform duration-300 md:transition-none
+          ${isMobileMenuOpen ? "translate-x-0 w-72" : "-translate-x-full md:translate-x-0"}
+        `}
+      >
+        {/* Header Options */}
+        <div className="flex flex-col border-b border-white/5">
+          <div className="flex items-center justify-between h-16 px-4">
+            <AnimatePresence mode="popLayout">
+              {!isDesktopCollapsed && (
+                <motion.div 
+                  initial={{ opacity: 0, width: 0 }}
+                  animate={{ opacity: 1, width: "auto" }}
+                  exit={{ opacity: 0, width: 0 }}
+                  className="flex-1 overflow-hidden"
+                >
+                  <Button 
+                    onClick={onNewChat} 
+                    className="w-full flex items-center justify-center gap-2 bg-white/5 hover:bg-white/10 text-white border-white/10 shadow-glow hover:shadow-glow-lg transition-all" 
+                    variant="outline"
+                  >
+                    <Plus className="w-4 h-4" />
+                    <span className="truncate whitespace-nowrap">New Chat</span>
+                  </Button>
+                </motion.div>
+              )}
+            </AnimatePresence>
+
+            {isDesktopCollapsed && (
+               <Button 
+                 onClick={onNewChat} 
+                 variant="outline" 
+                 size="icon" 
+                 className="shrink-0 mx-auto bg-white/5 hover:bg-white/10 text-white border-white/10 shadow-glow"
+                 title="New Chat"
+               >
+                 <Plus className="w-4 h-4" />
+               </Button>
+            )}
+
+            {/* Mobile Close Toggle */}
+            <Button variant="ghost" size="icon" className="md:hidden shrink-0 text-white hover:bg-white/10 ml-auto" onClick={onCloseMobileSidebar}>
+              <X className="w-4 h-4" />
+            </Button>
+          </div>
+
+          <AnimatePresence>
+            {!isDesktopCollapsed && (
+              <motion.div 
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: "auto" }}
+                exit={{ opacity: 0, height: 0 }}
+                className="relative group overflow-hidden px-4 pb-4"
+              >
+                <Search className="absolute left-7 top-1/2 -translate-y-1/2 w-4 h-4 text-white/40 group-focus-within:text-purple-400 transition-colors" />
+                <input 
+                  type="text" 
+                  placeholder="Search chats..." 
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="w-full h-9 bg-white/5 border border-white/10 rounded-lg pl-9 pr-3 text-sm text-white placeholder:text-white/40 focus:outline-none focus:border-purple-500/50 focus:ring-1 focus:ring-purple-500/50 transition-all"
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+        
+        {/* Conversation List */}
+        <div className="flex-1 overflow-y-auto p-3 space-y-6 scrollbar-thin scrollbar-thumb-white/10 hover:scrollbar-thumb-white/20 overflow-x-hidden">
+          {filteredConversations.length === 0 ? (
+            <AnimatePresence>
+              {!isDesktopCollapsed && (
+                <motion.div 
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  className="text-center p-4 text-xs text-white/40 mt-4 whitespace-nowrap"
+                >
+                  {searchQuery ? "No matches found" : "No conversations"}
+                </motion.div>
+              )}
+            </AnimatePresence>
+          ) : (
+            Object.entries(grouped).map(([label, items]) => {
+              if (items.length === 0) return null;
+              return (
+                <div key={label} className="space-y-1.5 flex flex-col items-center md:items-stretch">
+                  <AnimatePresence>
+                    {!isDesktopCollapsed && (
+                      <motion.h3 
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        className="px-3 text-[10px] font-semibold text-white/30 uppercase tracking-wider mb-2 whitespace-nowrap overflow-hidden"
+                      >
+                        {label}
+                      </motion.h3>
+                    )}
+                  </AnimatePresence>
+                  
+                  {items.map(conv => (
+                    <div
+                      key={conv.id}
+                      onClick={() => {
+                        onSelectConversation(conv.id);
+                        if (window.innerWidth < 768) {
+                          onCloseMobileSidebar();
+                        }
+                      }}
+                      title={isDesktopCollapsed ? conv.title : undefined}
+                      className={`
+                        group flex items-center justify-between p-3 rounded-xl cursor-pointer transition-all duration-200 text-sm border
+                        ${activeConversationId === conv.id 
+                          ? "bg-purple-500/20 border-purple-500/40 text-purple-50 shadow-[inset_0_0_20px_rgba(168,85,247,0.2)]" 
+                          : "bg-transparent border-transparent hover:bg-white/5 text-white/70 hover:text-white"}
+                        ${isDesktopCollapsed ? "justify-center w-10 h-10 p-0 mx-auto" : ""}
+                      `}
+                    >
+                      <div className={`flex items-center gap-3 overflow-hidden ${isDesktopCollapsed ? "justify-center" : ""}`}>
+                        <MessageSquare className={`w-4 h-4 shrink-0 transition-colors ${activeConversationId === conv.id ? "text-purple-400" : "opacity-50"}`} />
+                        <AnimatePresence>
+                          {!isDesktopCollapsed && (
+                            <motion.span 
+                              initial={{ opacity: 0, width: 0 }}
+                              animate={{ opacity: 1, width: "auto" }}
+                              exit={{ opacity: 0, width: 0 }}
+                              className="truncate whitespace-nowrap"
+                            >
+                              {conv.title}
+                            </motion.span>
+                          )}
+                        </AnimatePresence>
+                      </div>
+                      
+                      {!isDesktopCollapsed && (
+                        <button
+                          onClick={(e) => onDeleteConversation(e, conv.id)}
+                          className="opacity-0 group-hover:opacity-100 p-1.5 hover:bg-red-500/20 text-white/40 hover:text-red-400 rounded-md transition-all shrink-0"
+                          title="Delete Chat"
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              );
+            })
+          )}
+        </div>
+      </motion.div>
+    </>
+  );
+}

--- a/src/pages/MentorChatPage.tsx
+++ b/src/pages/MentorChatPage.tsx
@@ -23,6 +23,13 @@ interface MentorChatPageProps {
   jobs: JobApplication[];
 }
 
+interface MentorChatHistoryMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  created_at: string;
+}
+
 export default function MentorChatPage({ user, profile, sessions, mocks, jobs }: MentorChatPageProps) {
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [activeConversationId, setActiveConversationId] = useState<string | null>(null);
@@ -81,7 +88,7 @@ export default function MentorChatPage({ user, profile, sessions, mocks, jobs }:
     }
     const fetchHistory = async () => {
       try {
-        const msgs = await apiRequest<any[]>(`/api/users/${user.id}/mentor-chat/conversations/${activeConversationId}`);
+        const msgs = await apiRequest<MentorChatHistoryMessage[]>(`/api/users/${user.id}/mentor-chat/conversations/${activeConversationId}`);
         setMessages(msgs.map(m => ({ id: m.id, role: m.role, content: m.content })));
       } catch (err) {
         console.error("Failed to fetch history", err);
@@ -154,17 +161,14 @@ export default function MentorChatPage({ user, profile, sessions, mocks, jobs }:
         }))
       };
 
-      const payload: any = {
+      const payload = {
         conversation_id: activeConversationId || undefined,
         message: trimmed,
         skills,
         readiness_score: readinessScore,
-        profile: enrichedProfile
+        profile: enrichedProfile,
+        ...(!isHistoryEnabled ? { history: messages.map(m => ({ role: m.role, content: m.content })) } : {})
       };
-      
-      if (!isHistoryEnabled) {
-        payload.history = messages.map(m => ({ role: m.role, content: m.content }));
-      }
 
       const response = await apiRequest<{ reply: string; conversation_id: string }>(`/api/users/${user.id}/mentor-chat`, {
         method: "POST",
@@ -196,6 +200,17 @@ export default function MentorChatPage({ user, profile, sessions, mocks, jobs }:
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSend();
+    }
+  };
+
+  const handleRetry = () => {
+    if (
+      messages.length > 0 &&
+      messages[messages.length - 1].role === "user"
+    ) {
+      const lastMessage = messages[messages.length - 1].content;
+      setMessages((prev) => prev.slice(0, -1));
+      handleSend(lastMessage);
     }
   };
 

--- a/src/pages/MentorChatPage.tsx
+++ b/src/pages/MentorChatPage.tsx
@@ -1,20 +1,18 @@
 import { useState, useRef, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Send, Bot, User as UserIcon, AlertCircle, RefreshCcw, Menu, Plus, MessageSquare, Trash2, X } from "lucide-react";
+import { Send, Bot, User as UserIcon, AlertCircle, RefreshCcw, Menu, Info, Sparkles, PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 import { User, CareerProfile, InterviewSession, MockAttempt, JobApplication } from "@/lib/store";
 import { apiRequest } from "@/lib/api";
+
+import { CyberBackground } from "@/components/mentor/CyberBackground";
+import { MentorSidebar, Conversation } from "@/components/mentor/MentorSidebar";
 
 interface Message {
   id: string;
   role: "user" | "assistant";
   content: string;
-}
-
-interface Conversation {
-  id: string;
-  title: string;
-  updated_at: string;
 }
 
 interface MentorChatPageProps {
@@ -34,7 +32,9 @@ export default function MentorChatPage({ user, profile, sessions, mocks, jobs }:
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   
-  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [isDesktopCollapsed, setIsDesktopCollapsed] = useState(false);
+  const [isHistoryEnabled, setIsHistoryEnabled] = useState(true);
   
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -48,11 +48,23 @@ export default function MentorChatPage({ user, profile, sessions, mocks, jobs }:
   }, [messages, isLoading]);
 
   useEffect(() => {
+    const fetchSettings = async () => {
+      try {
+        const res = await apiRequest<{ mentor_history_enabled: boolean }>(`/api/users/${user.id}/mentor-chat/settings`);
+        setIsHistoryEnabled(res.mentor_history_enabled);
+      } catch (err) {
+        console.error("Failed to fetch mentor settings", err);
+      }
+    };
+    fetchSettings();
+  }, [user.id]);
+
+  useEffect(() => {
     const fetchConversations = async () => {
       try {
         const data = await apiRequest<Conversation[]>(`/api/users/${user.id}/mentor-chat/conversations`);
         setConversations(data);
-        if (data.length > 0 && !activeConversationId) {
+        if (data.length > 0 && !activeConversationId && isHistoryEnabled) {
           setActiveConversationId(data[0].id);
         }
       } catch (err) {
@@ -77,6 +89,22 @@ export default function MentorChatPage({ user, profile, sessions, mocks, jobs }:
     };
     fetchHistory();
   }, [activeConversationId, user.id]);
+
+  const toggleHistory = async (checked: boolean) => {
+    setIsHistoryEnabled(checked);
+    if (!checked) {
+      setActiveConversationId(null);
+    }
+    try {
+      await apiRequest(`/api/users/${user.id}/mentor-chat/settings`, {
+        method: "PATCH",
+        body: JSON.stringify({ mentor_history_enabled: checked }),
+      });
+    } catch (err) {
+      console.error("Failed to toggle setting", err);
+      setIsHistoryEnabled(!checked);
+    }
+  };
 
   const handleSend = async (messageText: string = input) => {
     const trimmed = messageText.trim();
@@ -126,15 +154,21 @@ export default function MentorChatPage({ user, profile, sessions, mocks, jobs }:
         }))
       };
 
+      const payload: any = {
+        conversation_id: activeConversationId || undefined,
+        message: trimmed,
+        skills,
+        readiness_score: readinessScore,
+        profile: enrichedProfile
+      };
+      
+      if (!isHistoryEnabled) {
+        payload.history = messages.map(m => ({ role: m.role, content: m.content }));
+      }
+
       const response = await apiRequest<{ reply: string; conversation_id: string }>(`/api/users/${user.id}/mentor-chat`, {
         method: "POST",
-        body: JSON.stringify({
-          conversation_id: activeConversationId || undefined,
-          message: trimmed,
-          skills,
-          readiness_score: readinessScore,
-          profile: enrichedProfile
-        }),
+        body: JSON.stringify(payload),
       });
 
       const assistantMessage: Message = {
@@ -145,7 +179,7 @@ export default function MentorChatPage({ user, profile, sessions, mocks, jobs }:
 
       setMessages((prev) => [...prev, assistantMessage]);
       
-      if (!activeConversationId) {
+      if (isHistoryEnabled && !activeConversationId && response.conversation_id) {
         setActiveConversationId(response.conversation_id);
         const updated = await apiRequest<Conversation[]>(`/api/users/${user.id}/mentor-chat/conversations`);
         setConversations(updated);
@@ -165,14 +199,6 @@ export default function MentorChatPage({ user, profile, sessions, mocks, jobs }:
     }
   };
 
-  const handleRetry = () => {
-    if (messages.length > 0 && messages[messages.length - 1].role === "user") {
-      const lastMessage = messages[messages.length - 1].content;
-      setMessages((prev) => prev.slice(0, -1));
-      handleSend(lastMessage);
-    }
-  };
-
   const handleDeleteConversation = async (e: React.MouseEvent, id: string) => {
     e.stopPropagation();
     try {
@@ -187,117 +213,98 @@ export default function MentorChatPage({ user, profile, sessions, mocks, jobs }:
     }
   };
 
-  const createNewChat = () => {
-    setActiveConversationId(null);
-    setMessages([]);
-    setIsSidebarOpen(false);
-  };
-
   return (
-    <div className="flex h-[calc(100vh-8rem)] rounded-xl border bg-card shadow-sm overflow-hidden animate-slide-up relative">
-      
-      {/* Mobile Sidebar Overlay */}
-      {isSidebarOpen && (
-        <div 
-          className="absolute inset-0 bg-background/80 backdrop-blur-sm z-20 md:hidden"
-          onClick={() => setIsSidebarOpen(false)}
-        />
-      )}
+    <div className="flex h-[calc(100vh-8rem)] rounded-2xl border border-white/10 shadow-2xl overflow-hidden relative group/chat-container">
+      <CyberBackground />
 
-      {/* Sidebar */}
-      <div className={`
-        absolute md:relative z-30
-        w-64 h-full bg-muted/30 border-r border-border flex flex-col
-        transition-transform duration-300 ease-in-out
-        ${isSidebarOpen ? "translate-x-0" : "-translate-x-full md:translate-x-0"}
-      `}>
-        <div className="p-4 flex items-center justify-between">
-          <Button onClick={createNewChat} className="w-full flex items-center gap-2" variant="outline">
-            <Plus className="w-4 h-4" />
-            New Chat
-          </Button>
-          <Button variant="ghost" size="icon" className="md:hidden ml-2" onClick={() => setIsSidebarOpen(false)}>
-            <X className="w-4 h-4" />
-          </Button>
-        </div>
-        
-        <div className="flex-1 overflow-y-auto p-2 space-y-1">
-          {conversations.length === 0 ? (
-            <div className="text-center p-4 text-xs text-muted-foreground mt-4">
-              No previous conversations
-            </div>
-          ) : (
-            conversations.map(conv => (
-              <div
-                key={conv.id}
-                onClick={() => {
-                  setActiveConversationId(conv.id);
-                  setIsSidebarOpen(false);
-                }}
-                className={`
-                  group flex items-center justify-between p-3 rounded-lg cursor-pointer transition-colors text-sm
-                  ${activeConversationId === conv.id ? "bg-primary/10 text-primary font-medium" : "hover:bg-muted text-foreground"}
-                `}
-              >
-                <div className="flex items-center gap-3 overflow-hidden">
-                  <MessageSquare className="w-4 h-4 shrink-0 opacity-70" />
-                  <span className="truncate">{conv.title}</span>
-                </div>
-                <button
-                  onClick={(e) => handleDeleteConversation(e, conv.id)}
-                  className="opacity-0 group-hover:opacity-100 p-1 hover:bg-destructive/10 hover:text-destructive rounded transition-all shrink-0"
-                  title="Delete Chat"
-                >
-                  <Trash2 className="w-3.5 h-3.5" />
-                </button>
-              </div>
-            ))
-          )}
-        </div>
-      </div>
+      <MentorSidebar
+        conversations={conversations}
+        activeConversationId={activeConversationId}
+        isMobileMenuOpen={isMobileMenuOpen}
+        isDesktopCollapsed={isDesktopCollapsed}
+        onSelectConversation={setActiveConversationId}
+        onDeleteConversation={handleDeleteConversation}
+        onNewChat={() => {
+          setActiveConversationId(null);
+          setMessages([]);
+          setIsMobileMenuOpen(false);
+        }}
+        onCloseMobileSidebar={() => setIsMobileMenuOpen(false)}
+        onToggleCollapse={() => setIsDesktopCollapsed(prev => !prev)}
+      />
 
       {/* Main Chat Area */}
-      <div className="flex-1 flex flex-col min-w-0 h-full">
+      <div className="flex-1 flex flex-col min-w-0 h-full relative z-10">
+        
         {/* Header */}
-        <div className="flex items-center gap-3 p-4 border-b bg-muted/10 h-16 shrink-0">
-          <Button variant="ghost" size="icon" className="md:hidden -ml-2 shrink-0" onClick={() => setIsSidebarOpen(true)}>
-            <Menu className="w-5 h-5" />
-          </Button>
-          <div className="w-8 h-8 rounded-full gradient-primary flex items-center justify-center text-primary-foreground shadow-glow shrink-0">
-            <Bot className="w-5 h-5" />
+        <div className="flex items-center justify-between p-4 border-b border-white/5 bg-black/40 backdrop-blur-xl h-16 shrink-0 shadow-sm">
+          <div className="flex items-center gap-4 min-w-0 flex-1">
+            <Button variant="ghost" size="icon" className="md:hidden -ml-2 shrink-0 text-white/70 hover:bg-white/10 hover:text-white" onClick={() => setIsMobileMenuOpen(true)}>
+              <Menu className="w-5 h-5" />
+            </Button>
+            
+            <Button 
+              variant="ghost" 
+              size="icon" 
+              className="hidden md:flex -ml-2 shrink-0 text-white/50 hover:text-white hover:bg-white/10 transition-colors" 
+              onClick={() => setIsDesktopCollapsed(prev => !prev)}
+              title={isDesktopCollapsed ? "Open Sidebar" : "Close Sidebar"}
+            >
+              {isDesktopCollapsed ? <PanelLeftOpen className="w-5 h-5" /> : <PanelLeftClose className="w-5 h-5" />}
+            </Button>
+
+            <div className="w-9 h-9 rounded-full bg-gradient-to-br from-purple-500 to-blue-600 flex items-center justify-center text-white shadow-[0_0_15px_rgba(168,85,247,0.4)] shrink-0">
+              <Bot className="w-5 h-5" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <h1 className="font-semibold text-white/90 truncate text-base tracking-wide flex items-center gap-2">
+                AI Mentor
+                {!isHistoryEnabled && <span className="px-2 py-0.5 rounded-full bg-orange-500/20 text-orange-400 text-[10px] uppercase font-bold tracking-wider border border-orange-500/30">Private</span>}
+              </h1>
+            </div>
           </div>
-          <div className="min-w-0 flex-1">
-            <h1 className="font-semibold text-foreground truncate">
-              {activeConversationId 
-                ? conversations.find(c => c.id === activeConversationId)?.title || "AI Mentor"
-                : "New Chat"}
-            </h1>
+          
+          <div className="flex flex-col items-end gap-1 pl-2">
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-medium text-white/50 whitespace-nowrap hidden sm:inline">
+                Save History
+              </span>
+              <Switch
+                checked={isHistoryEnabled}
+                onCheckedChange={toggleHistory}
+                className="data-[state=checked]:bg-purple-500"
+              />
+            </div>
           </div>
         </div>
 
-        {/* Messages */}
-        <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-6">
+        {/* Messages Container */}
+        <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-6 scrollbar-thin scrollbar-thumb-white/10 hover:scrollbar-thumb-white/20">
           {messages.length === 0 ? (
-            <div className="h-full flex flex-col items-center justify-center text-center space-y-4 text-muted-foreground">
-              <div className="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center">
-                <Bot className="w-8 h-8 text-primary" />
+            <div className="h-full flex flex-col items-center justify-center text-center space-y-6">
+              <div className="relative">
+                <div className="absolute inset-0 bg-purple-500/20 blur-2xl rounded-full animate-pulse-glow" />
+                <div className="relative w-20 h-20 rounded-2xl bg-black/40 backdrop-blur-md border border-white/10 flex items-center justify-center shadow-2xl">
+                  <Bot className="w-10 h-10 text-purple-400" />
+                  <Sparkles className="absolute -top-2 -right-2 w-5 h-5 text-blue-400 animate-pulse" />
+                </div>
               </div>
-              <div>
-                <p className="font-medium text-foreground text-lg">How can I help you today, {user.name}?</p>
-                <p className="text-sm max-w-md mx-auto mt-2">
+              <div className="space-y-2">
+                <h2 className="text-2xl font-semibold text-white tracking-tight">AI Mentor Ready</h2>
+                <p className="text-sm text-white/50 max-w-md mx-auto">
                   Ask me about interview strategies, resume reviews, salary negotiation, or what skills to focus on next.
                 </p>
               </div>
-              <div className="flex flex-wrap justify-center gap-2 mt-4 max-w-lg">
+              <div className="flex flex-wrap justify-center gap-3 mt-4 max-w-2xl">
                 {[
-                  "How do I answer 'Tell me about yourself'?",
-                  "Can you review my skills for a Frontend role?",
+                  "Review my skills for a Frontend role",
                   "What's a good study plan for system design?",
+                  "How do I answer 'Tell me about yourself'?",
                 ].map((suggestion) => (
                   <button
                     key={suggestion}
                     onClick={() => setInput(suggestion)}
-                    className="px-3 py-1.5 text-xs rounded-full border border-border bg-background hover:bg-muted transition-colors text-foreground"
+                    className="px-4 py-2 text-xs rounded-full border border-white/10 bg-white/5 hover:bg-white/10 hover:border-purple-500/30 transition-all text-white/70 hover:text-white shadow-sm"
                   >
                     {suggestion}
                   </button>
@@ -309,30 +316,30 @@ export default function MentorChatPage({ user, profile, sessions, mocks, jobs }:
               {messages.map((msg) => (
                 <motion.div
                   key={msg.id}
-                  initial={{ opacity: 0, y: 10 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  className={`flex gap-3 max-w-[85%] ${
+                  initial={{ opacity: 0, y: 15, filter: "blur(4px)" }}
+                  animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
+                  className={`flex gap-4 max-w-[85%] ${
                     msg.role === "user" ? "ml-auto flex-row-reverse" : ""
                   }`}
                 >
                   <div
-                    className={`w-8 h-8 rounded-full flex-shrink-0 flex items-center justify-center ${
+                    className={`w-9 h-9 rounded-full flex-shrink-0 flex items-center justify-center shadow-lg ${
                       msg.role === "user"
-                        ? "bg-primary text-primary-foreground"
-                        : "bg-muted text-muted-foreground"
+                        ? "bg-gradient-to-br from-blue-600 to-purple-600 text-white"
+                        : "bg-black/50 border border-white/10 text-purple-400 backdrop-blur-md"
                     }`}
                   >
                     {msg.role === "user" ? (
                       <UserIcon className="w-4 h-4" />
                     ) : (
-                      <Bot className="w-4 h-4" />
+                      <Bot className="w-5 h-5" />
                     )}
                   </div>
                   <div
-                    className={`rounded-2xl px-4 py-3 text-sm ${
+                    className={`rounded-2xl px-5 py-3.5 text-sm leading-relaxed shadow-lg backdrop-backdrop-blur-md ${
                       msg.role === "user"
-                        ? "bg-primary text-primary-foreground rounded-tr-none"
-                        : "bg-muted text-foreground rounded-tl-none whitespace-pre-wrap"
+                        ? "bg-gradient-to-br from-purple-900/40 to-blue-900/40 border border-purple-500/20 text-white rounded-tr-sm"
+                        : "bg-black/40 border border-white/10 text-white/90 rounded-tl-sm whitespace-pre-wrap"
                     }`}
                   >
                     {msg.content}
@@ -346,18 +353,17 @@ export default function MentorChatPage({ user, profile, sessions, mocks, jobs }:
             <motion.div
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
-              className="flex gap-3 max-w-[85%]"
+              className="flex gap-4 max-w-[85%]"
             >
-              <div className="w-8 h-8 rounded-full bg-muted text-muted-foreground flex items-center justify-center">
-                <Bot className="w-4 h-4" />
+              <div className="w-9 h-9 rounded-full flex-shrink-0 flex items-center justify-center shadow-lg bg-black/50 border border-white/10 text-purple-400 backdrop-blur-md">
+                <Bot className="w-5 h-5" />
               </div>
-              <div className="rounded-2xl px-4 py-3 bg-muted text-muted-foreground rounded-tl-none text-sm flex items-center gap-2">
-                <span className="flex space-x-1">
-                  <span className="animate-bounce">.</span>
-                  <span className="animate-bounce" style={{ animationDelay: "0.2s" }}>.</span>
-                  <span className="animate-bounce" style={{ animationDelay: "0.4s" }}>.</span>
-                </span>
-                AI Mentor is thinking...
+              <div className="rounded-2xl px-5 py-4 bg-black/40 border border-white/10 text-white/60 rounded-tl-sm text-sm flex items-center gap-2 backdrop-blur-md shadow-lg">
+                <div className="flex space-x-1.5 items-center h-2">
+                  <div className="w-1.5 h-1.5 bg-purple-500/70 rounded-full animate-bounce [animation-delay:-0.3s]" />
+                  <div className="w-1.5 h-1.5 bg-purple-500/70 rounded-full animate-bounce [animation-delay:-0.15s]" />
+                  <div className="w-1.5 h-1.5 bg-purple-500/70 rounded-full animate-bounce" />
+                </div>
               </div>
             </motion.div>
           )}
@@ -366,12 +372,12 @@ export default function MentorChatPage({ user, profile, sessions, mocks, jobs }:
             <motion.div
               initial={{ opacity: 0, scale: 0.95 }}
               animate={{ opacity: 1, scale: 1 }}
-              className="mx-auto max-w-sm rounded-xl bg-destructive/10 border border-destructive/20 p-3 flex flex-col items-center text-center gap-2"
+              className="mx-auto max-w-sm rounded-xl bg-red-950/40 border border-red-500/20 p-4 flex flex-col items-center text-center gap-3 backdrop-blur-md"
             >
-              <AlertCircle className="w-5 h-5 text-destructive" />
-              <p className="text-xs text-destructive">{error}</p>
-              <Button size="sm" variant="outline" className="h-7 text-xs border-destructive/30 text-destructive hover:bg-destructive/10" onClick={handleRetry}>
-                <RefreshCcw className="w-3 h-3 mr-1" /> Retry
+              <AlertCircle className="w-6 h-6 text-red-400" />
+              <p className="text-xs text-red-200">{error}</p>
+              <Button size="sm" variant="outline" className="h-8 text-xs border-red-500/30 text-red-400 hover:bg-red-500/20 hover:text-red-300" onClick={handleRetry}>
+                <RefreshCcw className="w-3 h-3 mr-1" /> Retry Connection
               </Button>
             </motion.div>
           )}
@@ -379,32 +385,38 @@ export default function MentorChatPage({ user, profile, sessions, mocks, jobs }:
         </div>
 
         {/* Input Area */}
-        <div className="p-4 bg-background border-t">
-          <div className="relative max-w-4xl mx-auto flex items-end gap-2">
-            <textarea
-              ref={inputRef}
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="Ask your AI Mentor anything..."
-              className="w-full min-h-[52px] max-h-32 resize-none rounded-xl border border-input bg-background px-4 py-3 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 pr-12 scrollbar-thin"
-              rows={1}
-              disabled={isLoading}
-            />
+        <div className="p-4 bg-black/40 backdrop-blur-xl border-t border-white/5 relative z-20">
+          <div className="relative max-w-4xl mx-auto flex items-end gap-3">
+            <div className="relative flex-1 group">
+              <div className="absolute -inset-0.5 bg-gradient-to-r from-purple-500/20 to-blue-500/20 rounded-xl blur opacity-0 group-focus-within:opacity-100 transition duration-500" />
+              <textarea
+                ref={inputRef}
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Ask your AI Mentor anything..."
+                className="relative w-full min-h-[56px] max-h-32 resize-none rounded-xl border border-white/10 bg-black/60 px-4 py-3.5 text-sm text-white placeholder:text-white/30 focus:outline-none focus:border-purple-500/40 disabled:cursor-not-allowed disabled:opacity-50 pr-14 scrollbar-thin scrollbar-thumb-white/10 shadow-inner transition-colors"
+                rows={1}
+                disabled={isLoading}
+              />
+            </div>
             <Button
               size="icon"
               onClick={() => handleSend()}
               disabled={!input.trim() || isLoading}
-              className={`absolute right-2 bottom-1.5 h-9 w-9 rounded-lg transition-all ${
-                input.trim() && !isLoading ? "gradient-primary text-primary-foreground shadow-md" : ""
+              className={`absolute right-3 bottom-2 h-10 w-10 rounded-lg transition-all duration-300 ${
+                input.trim() && !isLoading 
+                  ? "bg-gradient-to-br from-purple-600 to-blue-600 hover:from-purple-500 hover:to-blue-500 text-white shadow-[0_0_15px_rgba(168,85,247,0.4)] hover:shadow-[0_0_20px_rgba(168,85,247,0.6)]" 
+                  : "bg-white/5 text-white/30 border border-white/5"
               }`}
             >
               <Send className="w-4 h-4" />
               <span className="sr-only">Send message</span>
             </Button>
           </div>
-          <p className="text-center text-[10px] text-muted-foreground mt-2">
-            AI Mentor can make mistakes. Verify important career advice.
+          <p className="text-center text-[10px] text-white/30 mt-3 flex items-center justify-center gap-1.5">
+            <Info className="w-3 h-3" />
+            AI Mentor responses are generated dynamically and should be verified.
           </p>
         </div>
       </div>

--- a/src/pages/MentorChatPage.tsx
+++ b/src/pages/MentorChatPage.tsx
@@ -1,0 +1,413 @@
+import { useState, useRef, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Send, Bot, User as UserIcon, AlertCircle, RefreshCcw, Menu, Plus, MessageSquare, Trash2, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { User, CareerProfile, InterviewSession, MockAttempt, JobApplication } from "@/lib/store";
+import { apiRequest } from "@/lib/api";
+
+interface Message {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+}
+
+interface Conversation {
+  id: string;
+  title: string;
+  updated_at: string;
+}
+
+interface MentorChatPageProps {
+  user: User;
+  profile: CareerProfile | null;
+  sessions: InterviewSession[];
+  mocks: MockAttempt[];
+  jobs: JobApplication[];
+}
+
+export default function MentorChatPage({ user, profile, sessions, mocks, jobs }: MentorChatPageProps) {
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [activeConversationId, setActiveConversationId] = useState<string | null>(null);
+  
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages, isLoading]);
+
+  useEffect(() => {
+    const fetchConversations = async () => {
+      try {
+        const data = await apiRequest<Conversation[]>(`/api/users/${user.id}/mentor-chat/conversations`);
+        setConversations(data);
+        if (data.length > 0 && !activeConversationId) {
+          setActiveConversationId(data[0].id);
+        }
+      } catch (err) {
+        console.error("Failed to fetch conversations", err);
+      }
+    };
+    fetchConversations();
+  }, [user.id]);
+
+  useEffect(() => {
+    if (!activeConversationId) {
+      setMessages([]);
+      return;
+    }
+    const fetchHistory = async () => {
+      try {
+        const msgs = await apiRequest<any[]>(`/api/users/${user.id}/mentor-chat/conversations/${activeConversationId}`);
+        setMessages(msgs.map(m => ({ id: m.id, role: m.role, content: m.content })));
+      } catch (err) {
+        console.error("Failed to fetch history", err);
+      }
+    };
+    fetchHistory();
+  }, [activeConversationId, user.id]);
+
+  const handleSend = async (messageText: string = input) => {
+    const trimmed = messageText.trim();
+    if (!trimmed || isLoading) return;
+
+    const userMessage: Message = {
+      id: Date.now().toString(),
+      role: "user",
+      content: trimmed,
+    };
+
+    setMessages((prev) => [...prev, userMessage]);
+    setInput("");
+    setError(null);
+    setIsLoading(true);
+
+    try {
+      const skills = profile ? [
+        ...profile.technicalSkills.map(s => s.name),
+        ...profile.softSkills
+      ] : [];
+      
+      const latestSession = sessions.length > 0 
+        ? [...sessions].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0]
+        : null;
+        
+      const readinessScore = latestSession ? latestSession.readinessScore : 0;
+      
+      const enrichedProfile = {
+        ...(profile || {}),
+        prepContext: latestSession ? {
+          jobTitle: latestSession.jobTitle,
+          company: latestSession.company,
+          gapAnalysis: latestSession.gapAnalysis,
+          roadmap: latestSession.roadmap,
+          extractedSkills: latestSession.extractedSkills,
+        } : null,
+        mockPerformance: mocks.slice(-3).map(m => ({
+          question: m.question,
+          aiScore: m.aiScore,
+          verdict: m.aiFeedback.oneLineVerdict
+        })),
+        jobTrackerData: jobs.map(j => ({
+          company: j.companyName,
+          title: j.jobTitle,
+          status: j.status
+        }))
+      };
+
+      const response = await apiRequest<{ reply: string; conversation_id: string }>(`/api/users/${user.id}/mentor-chat`, {
+        method: "POST",
+        body: JSON.stringify({
+          conversation_id: activeConversationId || undefined,
+          message: trimmed,
+          skills,
+          readiness_score: readinessScore,
+          profile: enrichedProfile
+        }),
+      });
+
+      const assistantMessage: Message = {
+        id: (Date.now() + 1).toString(),
+        role: "assistant",
+        content: response.reply,
+      };
+
+      setMessages((prev) => [...prev, assistantMessage]);
+      
+      if (!activeConversationId) {
+        setActiveConversationId(response.conversation_id);
+        const updated = await apiRequest<Conversation[]>(`/api/users/${user.id}/mentor-chat/conversations`);
+        setConversations(updated);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to communicate with AI Mentor.");
+    } finally {
+      setIsLoading(false);
+      inputRef.current?.focus();
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  const handleRetry = () => {
+    if (messages.length > 0 && messages[messages.length - 1].role === "user") {
+      const lastMessage = messages[messages.length - 1].content;
+      setMessages((prev) => prev.slice(0, -1));
+      handleSend(lastMessage);
+    }
+  };
+
+  const handleDeleteConversation = async (e: React.MouseEvent, id: string) => {
+    e.stopPropagation();
+    try {
+      await apiRequest(`/api/users/${user.id}/mentor-chat/conversations/${id}`, { method: "DELETE" });
+      setConversations(prev => prev.filter(c => c.id !== id));
+      if (activeConversationId === id) {
+        setActiveConversationId(null);
+        setMessages([]);
+      }
+    } catch (err) {
+      console.error("Failed to delete", err);
+    }
+  };
+
+  const createNewChat = () => {
+    setActiveConversationId(null);
+    setMessages([]);
+    setIsSidebarOpen(false);
+  };
+
+  return (
+    <div className="flex h-[calc(100vh-8rem)] rounded-xl border bg-card shadow-sm overflow-hidden animate-slide-up relative">
+      
+      {/* Mobile Sidebar Overlay */}
+      {isSidebarOpen && (
+        <div 
+          className="absolute inset-0 bg-background/80 backdrop-blur-sm z-20 md:hidden"
+          onClick={() => setIsSidebarOpen(false)}
+        />
+      )}
+
+      {/* Sidebar */}
+      <div className={`
+        absolute md:relative z-30
+        w-64 h-full bg-muted/30 border-r border-border flex flex-col
+        transition-transform duration-300 ease-in-out
+        ${isSidebarOpen ? "translate-x-0" : "-translate-x-full md:translate-x-0"}
+      `}>
+        <div className="p-4 flex items-center justify-between">
+          <Button onClick={createNewChat} className="w-full flex items-center gap-2" variant="outline">
+            <Plus className="w-4 h-4" />
+            New Chat
+          </Button>
+          <Button variant="ghost" size="icon" className="md:hidden ml-2" onClick={() => setIsSidebarOpen(false)}>
+            <X className="w-4 h-4" />
+          </Button>
+        </div>
+        
+        <div className="flex-1 overflow-y-auto p-2 space-y-1">
+          {conversations.length === 0 ? (
+            <div className="text-center p-4 text-xs text-muted-foreground mt-4">
+              No previous conversations
+            </div>
+          ) : (
+            conversations.map(conv => (
+              <div
+                key={conv.id}
+                onClick={() => {
+                  setActiveConversationId(conv.id);
+                  setIsSidebarOpen(false);
+                }}
+                className={`
+                  group flex items-center justify-between p-3 rounded-lg cursor-pointer transition-colors text-sm
+                  ${activeConversationId === conv.id ? "bg-primary/10 text-primary font-medium" : "hover:bg-muted text-foreground"}
+                `}
+              >
+                <div className="flex items-center gap-3 overflow-hidden">
+                  <MessageSquare className="w-4 h-4 shrink-0 opacity-70" />
+                  <span className="truncate">{conv.title}</span>
+                </div>
+                <button
+                  onClick={(e) => handleDeleteConversation(e, conv.id)}
+                  className="opacity-0 group-hover:opacity-100 p-1 hover:bg-destructive/10 hover:text-destructive rounded transition-all shrink-0"
+                  title="Delete Chat"
+                >
+                  <Trash2 className="w-3.5 h-3.5" />
+                </button>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Main Chat Area */}
+      <div className="flex-1 flex flex-col min-w-0 h-full">
+        {/* Header */}
+        <div className="flex items-center gap-3 p-4 border-b bg-muted/10 h-16 shrink-0">
+          <Button variant="ghost" size="icon" className="md:hidden -ml-2 shrink-0" onClick={() => setIsSidebarOpen(true)}>
+            <Menu className="w-5 h-5" />
+          </Button>
+          <div className="w-8 h-8 rounded-full gradient-primary flex items-center justify-center text-primary-foreground shadow-glow shrink-0">
+            <Bot className="w-5 h-5" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h1 className="font-semibold text-foreground truncate">
+              {activeConversationId 
+                ? conversations.find(c => c.id === activeConversationId)?.title || "AI Mentor"
+                : "New Chat"}
+            </h1>
+          </div>
+        </div>
+
+        {/* Messages */}
+        <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-6">
+          {messages.length === 0 ? (
+            <div className="h-full flex flex-col items-center justify-center text-center space-y-4 text-muted-foreground">
+              <div className="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center">
+                <Bot className="w-8 h-8 text-primary" />
+              </div>
+              <div>
+                <p className="font-medium text-foreground text-lg">How can I help you today, {user.name}?</p>
+                <p className="text-sm max-w-md mx-auto mt-2">
+                  Ask me about interview strategies, resume reviews, salary negotiation, or what skills to focus on next.
+                </p>
+              </div>
+              <div className="flex flex-wrap justify-center gap-2 mt-4 max-w-lg">
+                {[
+                  "How do I answer 'Tell me about yourself'?",
+                  "Can you review my skills for a Frontend role?",
+                  "What's a good study plan for system design?",
+                ].map((suggestion) => (
+                  <button
+                    key={suggestion}
+                    onClick={() => setInput(suggestion)}
+                    className="px-3 py-1.5 text-xs rounded-full border border-border bg-background hover:bg-muted transition-colors text-foreground"
+                  >
+                    {suggestion}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <AnimatePresence initial={false}>
+              {messages.map((msg) => (
+                <motion.div
+                  key={msg.id}
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  className={`flex gap-3 max-w-[85%] ${
+                    msg.role === "user" ? "ml-auto flex-row-reverse" : ""
+                  }`}
+                >
+                  <div
+                    className={`w-8 h-8 rounded-full flex-shrink-0 flex items-center justify-center ${
+                      msg.role === "user"
+                        ? "bg-primary text-primary-foreground"
+                        : "bg-muted text-muted-foreground"
+                    }`}
+                  >
+                    {msg.role === "user" ? (
+                      <UserIcon className="w-4 h-4" />
+                    ) : (
+                      <Bot className="w-4 h-4" />
+                    )}
+                  </div>
+                  <div
+                    className={`rounded-2xl px-4 py-3 text-sm ${
+                      msg.role === "user"
+                        ? "bg-primary text-primary-foreground rounded-tr-none"
+                        : "bg-muted text-foreground rounded-tl-none whitespace-pre-wrap"
+                    }`}
+                  >
+                    {msg.content}
+                  </div>
+                </motion.div>
+              ))}
+            </AnimatePresence>
+          )}
+
+          {isLoading && (
+            <motion.div
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              className="flex gap-3 max-w-[85%]"
+            >
+              <div className="w-8 h-8 rounded-full bg-muted text-muted-foreground flex items-center justify-center">
+                <Bot className="w-4 h-4" />
+              </div>
+              <div className="rounded-2xl px-4 py-3 bg-muted text-muted-foreground rounded-tl-none text-sm flex items-center gap-2">
+                <span className="flex space-x-1">
+                  <span className="animate-bounce">.</span>
+                  <span className="animate-bounce" style={{ animationDelay: "0.2s" }}>.</span>
+                  <span className="animate-bounce" style={{ animationDelay: "0.4s" }}>.</span>
+                </span>
+                AI Mentor is thinking...
+              </div>
+            </motion.div>
+          )}
+
+          {error && (
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              className="mx-auto max-w-sm rounded-xl bg-destructive/10 border border-destructive/20 p-3 flex flex-col items-center text-center gap-2"
+            >
+              <AlertCircle className="w-5 h-5 text-destructive" />
+              <p className="text-xs text-destructive">{error}</p>
+              <Button size="sm" variant="outline" className="h-7 text-xs border-destructive/30 text-destructive hover:bg-destructive/10" onClick={handleRetry}>
+                <RefreshCcw className="w-3 h-3 mr-1" /> Retry
+              </Button>
+            </motion.div>
+          )}
+          <div ref={messagesEndRef} />
+        </div>
+
+        {/* Input Area */}
+        <div className="p-4 bg-background border-t">
+          <div className="relative max-w-4xl mx-auto flex items-end gap-2">
+            <textarea
+              ref={inputRef}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Ask your AI Mentor anything..."
+              className="w-full min-h-[52px] max-h-32 resize-none rounded-xl border border-input bg-background px-4 py-3 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 pr-12 scrollbar-thin"
+              rows={1}
+              disabled={isLoading}
+            />
+            <Button
+              size="icon"
+              onClick={() => handleSend()}
+              disabled={!input.trim() || isLoading}
+              className={`absolute right-2 bottom-1.5 h-9 w-9 rounded-lg transition-all ${
+                input.trim() && !isLoading ? "gradient-primary text-primary-foreground shadow-md" : ""
+              }`}
+            >
+              <Send className="w-4 h-4" />
+              <span className="sr-only">Send message</span>
+            </Button>
+          </div>
+          <p className="text-center text-[10px] text-muted-foreground mt-2">
+            AI Mentor can make mistakes. Verify important career advice.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

### What problem does this PR solve?

Previously, PrepIQ automatically stored mentor chat conversations without giving users control over chat persistence. Users could not choose between temporary/private chats and persistent history-based conversations.

### What changed?

This PR introduces a Mentor Chat History Toggle feature that allows users to enable or disable persistent chat history.

### Features Added

* Added chat history toggle setting
* Users can enable/disable mentor conversation persistence
* Temporary chat mode support
* Sidebar updates dynamically based on history setting
* Persistent chats remain saved when enabled
* Conversations are no longer stored when history is disabled
* Improved mentor chat state handling
* Maintained authenticated mentor chat functionality

### UI/UX Improvements

* Added modern toggle UI for chat history preference
* Added privacy-focused interaction flow
* Improved conversation management experience

### Backend Changes

* Added mentor history preference handling
* Conditional database persistence for mentor chats
* Preserved OpenRouter integration and context-aware responses

---

## Validation

* [x] `npm run build`
* [x] `npx tsc --noEmit`
* [x] `python -m compileall backend`

---

## Screenshots

Add screenshots for:


https://github.com/user-attachments/assets/fcb07e79-23a4-4edc-a1c5-e86bab05d130

https://github.com/user-attachments/assets/42086d94-65e2-4ecb-8f33-5c97acc0974b




---

## Risks

* Existing databases may require schema refresh/migration for new mentor history preference fields.
* Users with disabled history will lose temporary conversations after refresh/logout by design.
* Requires verification that sidebar state remains synchronized with history preference.
