### PR TITLE
feat: add global command palette navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { AppLayout } from "@/components/AppLayout";
 import { useAuth, useCareerProfile, useInterviewSessions, useMockAttempts, useJobApplications } from "@/lib/store";
 import Privacy from "./pages/Privacy";
 import Terms from "./pages/Terms";
+import { CommandPalette } from "./components/CommandPalette";
 
 const Index = lazy(() => import("./pages/Index"));
 const NotFound = lazy(() => import("./pages/NotFound"));
@@ -157,6 +158,7 @@ const App = () => (
         <Toaster />
         <ErrorBoundary>
           <BrowserRouter>
+            <CommandPalette />
             <AppRoutes />
           </BrowserRouter>
         </ErrorBoundary>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -76,6 +76,25 @@ export function AppSidebar({ onLogout }: AppSidebarProps) {
       </div>
 
       <SidebarContent>
+        <div className="px-2 py-2 hidden md:block">
+          <button
+            onClick={() => {
+              window.dispatchEvent(
+                new KeyboardEvent("keydown", {
+                  key: "k",
+                  ctrlKey: true,
+                })
+              );
+            }}
+            className="w-full flex items-center justify-between rounded-xl border border-border/60 bg-background/40 px-4 py-3 text-sm text-muted-foreground transition-all duration-200 hover:bg-white/5 hover:border-white/10 hover:text-foreground"
+          >
+            <span>Search pages...</span>
+
+            <kbd className="rounded border border-border bg-muted px-2 py-0.5 text-xs">
+              Ctrl K
+            </kbd>
+          </button>
+        </div>
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Search } from "lucide-react";
+import {
+    Dialog,
+    DialogContent,
+} from "@/components/ui/dialog";
+
+import { Input } from "@/components/ui/input";
+import { useLocation } from "react-router-dom";
+import { commandRoutes } from "@/data/commandRoutes";
+
+export function CommandPalette() {
+    const [open, setOpen] = useState(false);
+    const [query, setQuery] = useState("");
+    const [selectedIndex, setSelectedIndex] = useState(0);
+    const location = useLocation();
+    const navigate = useNavigate();
+    const inputRef = useRef<HTMLInputElement>(null);
+    const hiddenRoutes = ["/login", "/signup"];
+
+    useEffect(() => {
+        const down = (e: KeyboardEvent) => {
+            const isMac = navigator.platform.toUpperCase().includes("MAC");
+
+            if (
+                !hiddenRoutes.includes(location.pathname) &&
+                (
+                    (isMac && e.metaKey && e.key === "k") ||
+                    (!isMac && e.ctrlKey && e.key === "k")
+                )
+            ) {
+                e.preventDefault();
+                setOpen((prev) => !prev);
+            }
+
+            if (e.key === "Escape") {
+                setOpen(false);
+            }
+        };
+
+        window.addEventListener("keydown", down);
+
+        return () => window.removeEventListener("keydown", down);
+    }, []);
+    useEffect(() => {
+        if (open) {
+            setTimeout(() => {
+                inputRef.current?.focus();
+            }, 100);
+        }
+    }, [open]);
+
+    const filteredRoutes = useMemo(() => {
+        return commandRoutes.filter((route) =>
+            route.title.toLowerCase().includes(query.toLowerCase())
+        );
+    }, [query]);
+
+
+    useEffect(() => {
+        setSelectedIndex(0);
+    }, [query]);
+
+    useEffect(() => {
+        const handleKeys = (e: KeyboardEvent) => {
+            if (!open) return;
+
+            if (e.key === "ArrowDown") {
+                e.preventDefault();
+                setSelectedIndex((prev) =>
+                    prev + 1 >= filteredRoutes.length ? 0 : prev + 1
+                );
+            }
+
+            if (e.key === "ArrowUp") {
+                e.preventDefault();
+                setSelectedIndex((prev) =>
+                    prev - 1 < 0 ? filteredRoutes.length - 1 : prev - 1
+                );
+            }
+
+            if (e.key === "Enter") {
+                e.preventDefault();
+
+                const selected = filteredRoutes[selectedIndex];
+
+                if (selected) {
+                    navigate(selected.path);
+                    setOpen(false);
+                    setQuery("");
+                }
+            }
+        };
+
+        window.addEventListener("keydown", handleKeys);
+
+        return () => window.removeEventListener("keydown", handleKeys);
+    }, [open, filteredRoutes, selectedIndex, navigate]);
+
+    if (hiddenRoutes.includes(location.pathname)) {
+        return null;
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={setOpen}>
+            <DialogContent className="max-w-xl p-0 overflow-hidden border-border">
+                <div className="border-b border-border px-4 py-3 flex items-center gap-3">
+                    <Search className="h-4 w-4 text-muted-foreground" />
+
+                    <Input
+                        ref={inputRef}
+                        placeholder="Search pages..."
+                        value={query}
+                        onChange={(e) => setQuery(e.target.value)}
+                        className="border-0 focus-visible:ring-0 focus-visible:ring-offset-0 shadow-none"
+                    />
+                </div>
+
+                <div className="max-h-[350px] overflow-y-auto p-2">
+                    {filteredRoutes.length === 0 ? (
+                        <div className="text-sm text-muted-foreground px-3 py-6 text-center">
+                            No results found.
+                        </div>
+                    ) : (
+                        filteredRoutes.map((route, index) => {
+                            const Icon = route.icon;
+
+                            return (
+                                <button
+                                    key={route.path}
+                                    onClick={() => {
+                                        navigate(route.path);
+                                        setOpen(false);
+                                        setQuery("");
+                                    }}
+                                    className={`w-full flex items-center gap-3 rounded-lg px-3 py-3 text-left transition-colors
+                    ${selectedIndex === index
+                                            ? "bg-accent text-accent-foreground"
+                                            : "hover:bg-accent/50"
+                                        }
+                  `}
+                                >
+                                    <Icon className="h-4 w-4" />
+
+                                    <span className="text-sm font-medium">
+                                        {route.title}
+                                    </span>
+                                </button>
+                            );
+                        })
+                    )}
+                </div>
+
+                <div className="border-t border-border px-4 py-2 text-xs text-muted-foreground flex items-center justify-between">
+                    <span>↑↓ Navigate</span>
+                    <span>Enter Select</span>
+                    <span>Esc Close</span>
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -42,7 +42,7 @@ export function CommandPalette() {
         window.addEventListener("keydown", down);
 
         return () => window.removeEventListener("keydown", down);
-    }, []);
+    }, [location.pathname]);
     useEffect(() => {
         if (open) {
             setTimeout(() => {

--- a/src/data/commandRoutes.ts
+++ b/src/data/commandRoutes.ts
@@ -1,0 +1,47 @@
+import {
+    LayoutDashboard,
+    UserCircle,
+    BookOpen,
+    MessageSquare,
+    Briefcase,
+    TrendingUp,
+    Settings,
+} from "lucide-react";
+
+export const commandRoutes = [
+    {
+        title: "Dashboard",
+        path: "/dashboard",
+        icon: LayoutDashboard,
+    },
+    {
+        title: "Career DNA",
+        path: "/career-dna",
+        icon: UserCircle,
+    },
+    {
+        title: "Interview Prep",
+        path: "/interview-prep",
+        icon: BookOpen,
+    },
+    {
+        title: "Mock Interview",
+        path: "/mock-interview",
+        icon: MessageSquare,
+    },
+    {
+        title: "Job Tracker",
+        path: "/job-tracker",
+        icon: Briefcase,
+    },
+    {
+        title: "Progress",
+        path: "/progress",
+        icon: TrendingUp,
+    },
+    {
+        title: "Settings",
+        path: "/settings",
+        icon: Settings,
+    },
+];


### PR DESCRIPTION
## Summary

- What problem does this PR solve?
      - Currently users have to navigate to different pages by using mouse and then clicking on sidebar then going to page. Just to see their applications or anything. 
- What changed?
      - This PR adds a global command palette which can be accessed by pressing ctrl+k or cmd+k buttons
      - It is disabled on login/signup
      - Disabled on mobile
      - Anyone can press ctrl+k then move up down using the keys or type where they want to go and press enter and they will be on that page

Closes #141 

## Validation

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `python -m compileall backend`

## Screenshots


https://github.com/user-attachments/assets/d40479cd-8fa8-41d6-a925-2f3e918ee6cb

https://github.com/user-attachments/assets/6bac4277-d10b-4478-9737-c511e5860abc

## Risks

NA

AI Usage: AI used to fix the command palette coming on login pages and writing the commit message. 



