### PR TITLE
Fix: Backend Job Tracker API lacks server-side validation for job application inputs

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -437,6 +437,22 @@ class CreateJobApplicationRequest(BaseModel):
     jobUrl: str
     status: JobStatus
 
+    @field_validator("companyName", "jobTitle")
+    @classmethod
+    def non_empty(cls, v: str) -> str:
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("must not be empty or whitespace-only")
+        return stripped
+
+    @field_validator("jobUrl")
+    @classmethod
+    def valid_url(cls, v: str) -> str:
+        stripped = v.strip()
+        if not stripped.startswith(("http://", "https://")):
+            raise ValueError("must be a valid HTTP or HTTPS URL")
+        return stripped
+
 
 class UpdateJobApplicationRequest(BaseModel):
     companyName: str | None = None


### PR DESCRIPTION
Closes #175

**Root cause**: `CreateJobApplicationRequest` Pydantic model in `backend/app/main.py:434` defined fields with only type annotations (`str`) but no validators. This allowed empty strings, whitespace-only values, and invalid URLs to be accepted and persisted.

**Fix**: Added two Pydantic `@field_validator` decorators:
- `non_empty` — strips whitespace and rejects empty strings for `companyName` and `jobTitle`
- `valid_url` — rejects URLs that don't start with `http://` or `https://` for `jobUrl`

The backend now returns `HTTP 422 Unprocessable Entity` with descriptive error messages for invalid input.
