### PR TITLE
ux: add loading state to resume/JD text areas during document extraction

### DIFF
--- a/src/pages/InterviewPrepPage.tsx
+++ b/src/pages/InterviewPrepPage.tsx
@@ -234,7 +234,14 @@ export default function InterviewPrepPage({
                   </Button>
                 </div>
               </div>
-              <Textarea value={jd} onChange={(e) => setJd(e.target.value)} rows={4} className="bg-secondary/50" placeholder="Paste the job description or upload a file..." />
+              <Textarea
+                value={jd}
+                onChange={(e) => setJd(e.target.value)}
+                rows={4}
+                disabled={uploadingJd}
+                className={`bg-secondary/50 transition-opacity duration-200 ${uploadingJd ? "opacity-50" : ""}`}
+                placeholder={uploadingJd ? "Extracting text..." : "Paste the job description or upload a file..."}
+              />
             </div>
             <div>
               <div className="flex items-center justify-between mb-1">
@@ -268,7 +275,14 @@ export default function InterviewPrepPage({
                   </Button>
                 </div>
               </div>
-              <Textarea value={resume} onChange={(e) => setResume(e.target.value)} rows={4} className="bg-secondary/50" placeholder="Paste your resume content or upload a file..." />
+              <Textarea
+                value={resume}
+                onChange={(e) => setResume(e.target.value)}
+                rows={4}
+                disabled={uploadingResume}
+                className={`bg-secondary/50 transition-opacity duration-200 ${uploadingResume ? "opacity-50" : ""}`}
+                placeholder={uploadingResume ? "Extracting text..." : "Paste your resume content or upload a file..."}
+              />
             </div>
             <div className="flex gap-3">
               <Button type="submit" disabled={loading} className="gradient-primary text-primary-foreground">


### PR DESCRIPTION
## Summary

- **What problem does this PR solve?**
  Closes #149. During PDF or DOCX document uploads in `InterviewPrepPage.tsx`, the API extraction process takes a few seconds. Although the upload button updated to "Extracting...", the textareas had no visual feedback or input lock, allowing users to type or edit during active extraction and causing the UI to feel temporarily frozen.

- **What changed?**
  - Updated both the Job Description and Resume `<Textarea>` elements in `src/pages/InterviewPrepPage.tsx`:
    - Linked the `disabled` attribute to `uploadingJd` and `uploadingResume` state variables to lock inputs during document text extraction.
    - Added transition classes (`transition-opacity duration-200`) and temporary opacity (`opacity-50`) when loading is active to provide immediate visual feedback.
    - Set up a dynamic `placeholder` that displays `"Extracting text..."` while uploading is active, and automatically restores the standard placeholder once the file extraction completes.

## Validation

- [x] `npm run build` (builds successfully with the new properties)
- [x] `npx tsc --noEmit` (TypeScript compilation checks pass cleanly)
- [x] Manually validated that the textareas smoothly lower opacity, disable user input, and update their placeholders to `"Extracting text..."` during file uploads.

## Screenshots

*Minor frontend styling changes (disabled attribute and standard Tailwind `opacity-50` visual feedback).*

## Risks

- **No risks**: This is a purely visual/interactive frontend UX enhancement. The core document extraction API and state flows remain completely unmodified.
