### PR TITLE
feat: add Retake button on past attempts in MockInterviewPage (closes #180)

### DIFF
--- a/src/pages/MockInterviewPage.tsx
+++ b/src/pages/MockInterviewPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
 import {
   MessageSquare, Loader2, CheckCircle, XCircle,
@@ -183,6 +183,7 @@ export default function MockInterviewPage({
   const [expandedAttemptId, setExpandedAttemptId] = useState<string | null>(null);
   const [selectedSession, setSelectedSession] = useState<string>("custom");
   const { toast } = useToast();
+  const answerRef = useRef<HTMLTextAreaElement>(null);
 
   // ── NEW: AI question generation state ──────────────────────────────────
   const [selectedRole, setSelectedRole] = useState<string>("");
@@ -568,6 +569,7 @@ export default function MockInterviewPage({
               </div>
             </div>
             <Textarea
+              ref={answerRef}
               value={answer}
               onChange={(e) => setAnswer(e.target.value)}
               placeholder="Type your answer here..."
@@ -741,6 +743,19 @@ export default function MockInterviewPage({
                     </div>
                     <div className="flex items-center gap-2">
                       <Badge className={scoreColor(a.aiScore)}>{a.aiScore}/10</Badge>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                          beginQuestion(a.question);
+                          answerRef.current?.focus();
+                          answerRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+                        }}
+                      >
+                        <RefreshCw className="w-4 h-4 mr-1" />
+                        Retake
+                      </Button>
                       <Button
                         type="button"
                         variant="outline"


### PR DESCRIPTION
Close #180 
## Summary:
Problem: Once a user submits an answer to a mock interview 
question, there is no way to practice the same question 
again without manually retyping it.

## Changes:
- Added a "Retake" button on each past attempt card in 
  MockInterviewPage.tsx
- Clicking Retake pre-fills the question field with the 
  selected question using existing beginQuestion() function
- Clears the previous answer so user can start fresh
- Scrolls smoothly to the answer textarea and focuses it
- Original attempt remains in history unchanged
- Added useRef to the answer Textarea for smooth scroll 
  and focus behavior
- No backend changes required
## Validation:

✅ npm run build
✅ npx tsc --noEmit
✅ python -m compileall backend

## Screenshots:
Retake button now visible on each past attempt card 
next to the Review button. Clicking it pre-fills the 
question and scrolls to the answer input area.
N/A — Unable to run locally without backend credentials. 
The change is limited to adding a Retake button on the 
past attempt card in MockInterviewPage.tsx (frontend only).
## Risks:
No migration, deployment, or API concerns.
Frontend-only change limited to MockInterviewPage.tsx.
No existing functionality affected.