### PR TITLE
feat: add delete functionality for prep sessions with confirmation dialog

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,7 +107,7 @@ function ProtectedRoute({ hydrated, user, logout, resourceErrorMessage, children
 function AppRoutes() {
   const { user, login, signup, logout, hydrated } = useAuth();
   const { profile, saveProfile, profileError } = useCareerProfile(user?.id);
-  const { sessions, addSession, sessionsError } = useInterviewSessions(user?.id);
+  const { sessions, addSession, deleteSession, sessionsError } = useInterviewSessions(user?.id);
   const { attempts, addAttempt, attemptsError } = useMockAttempts(user?.id);
   const { jobs, addJob, updateJob, deleteJob, jobsError } = useJobApplications(user?.id);
   const resourceErrorMessage = profileError ?? sessionsError ?? attemptsError ?? jobsError;
@@ -125,6 +125,7 @@ function AppRoutes() {
           sessions={sessions}
           jobs={jobs}
           onAddSession={addSession}
+          onDeleteSession={deleteSession}
           userId={user?.id || ""}
         /></ProtectedRoute>} />
         <Route path="/mock-interview" element={<ProtectedRoute hydrated={hydrated} user={user} logout={logout} resourceErrorMessage={resourceErrorMessage}><MockInterviewPage sessions={sessions} attempts={attempts} onAddAttempt={addAttempt} userId={user?.id || ""} /></ProtectedRoute>} />

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -313,9 +313,26 @@ export function useInterviewSessions(userId: string | undefined) {
     return addSessionMutation.mutateAsync(input);
   }, [addSessionMutation]);
 
+  const deleteSessionMutation = useMutation({
+    mutationFn: (sessionId: string) => {
+      if (!userId) throw new Error("User is not authenticated");
+      return apiRequest<void>(`/api/users/${userId}/sessions/${sessionId}`, {
+        method: "DELETE",
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["interviewSessions", userId] });
+    },
+  });
+
+  const deleteSession = useCallback(async (sessionId: string) => {
+    return deleteSessionMutation.mutateAsync(sessionId);
+  }, [deleteSessionMutation]);
+
   return {
     sessions: sessionsQuery.data ?? [],
     addSession,
+    deleteSession,
     sessionsError: sessionsQuery.error instanceof Error ? sessionsQuery.error.message : null,
     sessionsLoading: sessionsQuery.isLoading,
   };

--- a/src/pages/InterviewPrepPage.tsx
+++ b/src/pages/InterviewPrepPage.tsx
@@ -1,8 +1,18 @@
 import { useState, useRef, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
-import { BookOpen, Loader2, Search, Brain, Cpu, Upload } from "lucide-react";
+import { BookOpen, Loader2, Search, Brain, Cpu, Upload, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -21,6 +31,7 @@ interface InterviewPrepPageProps {
   sessions: InterviewSession[];
   jobs: JobApplication[];
   onAddSession: (input: CreateInterviewSessionInput) => Promise<InterviewSession>;
+  onDeleteSession: (sessionId: string) => Promise<void>;
   userId: string;
 }
 
@@ -30,6 +41,7 @@ export default function InterviewPrepPage({
   sessions,
   jobs,
   onAddSession,
+  onDeleteSession,
 }: InterviewPrepPageProps) {
   const [showForm, setShowForm] = useState(false);
   const [jobTitle, setJobTitle] = useState("");
@@ -43,6 +55,8 @@ export default function InterviewPrepPage({
   const [selectedJobId, setSelectedJobId] = useState("");
   const [uploadingJd, setUploadingJd] = useState(false);
   const [uploadingResume, setUploadingResume] = useState(false);
+  const [sessionToDelete, setSessionToDelete] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
   const jdFileRef = useRef<HTMLInputElement>(null);
   const resumeFileRef = useRef<HTMLInputElement>(null);
   const { toast } = useToast();
@@ -143,6 +157,24 @@ export default function InterviewPrepPage({
       });
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleDeleteSession = async () => {
+    if (!sessionToDelete) return;
+    setDeleting(true);
+    try {
+      await onDeleteSession(sessionToDelete);
+      toast({ title: "Session deleted", description: "Prep session removed successfully." });
+      setSessionToDelete(null);
+    } catch (error) {
+      toast({
+        title: "Delete failed",
+        description: error instanceof Error ? error.message : "Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -531,16 +563,25 @@ export default function InterviewPrepPage({
             {[...sessions].reverse().map((s) => (
               <div
                 key={s.id}
-                onClick={() => setActiveSession(s)}
-                className="rounded-xl bg-card border border-border p-4 flex items-center justify-between hover:border-primary/30 transition-colors cursor-pointer"
+                className="rounded-xl bg-card border border-border p-4 flex items-center justify-between hover:border-primary/30 transition-colors"
               >
-                <div>
+                <div className="flex-1 cursor-pointer" onClick={() => setActiveSession(s)}>
                   <p className="font-medium text-foreground text-sm">{s.company} — {s.jobTitle}</p>
                   <p className="text-xs text-muted-foreground">{new Date(s.createdAt).toLocaleDateString()}</p>
                 </div>
-                <Badge className={s.readinessScore >= 70 ? "bg-success/20 text-success" : "bg-warning/20 text-warning"}>
-                  {s.readinessScore}%
-                </Badge>
+                <div className="flex items-center gap-2">
+                  <Badge className={s.readinessScore >= 70 ? "bg-success/20 text-success" : "bg-warning/20 text-warning"}>
+                    {s.readinessScore}%
+                  </Badge>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+                    onClick={(e) => { e.stopPropagation(); setSessionToDelete(s.id); }}
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </Button>
+                </div>
               </div>
             ))}
           </div>
@@ -557,6 +598,27 @@ export default function InterviewPrepPage({
           </Button>
         </div>
       )}
+
+      <AlertDialog open={!!sessionToDelete} onOpenChange={(open) => { if (!open) setSessionToDelete(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Prep Session?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete this prep session and cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={deleting}
+              onClick={handleDeleteSession}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {deleting ? "Deleting..." : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }


### PR DESCRIPTION
Closes #197 

## Summary

- **Problem:** Once a prep session was created there was no way to delete it, making the session list cluttered and unmanageable over time.
- **What changed:**
  - Added a trash icon button to each past session card in `InterviewPrepPage.tsx`
  - Clicking it opens an `AlertDialog` confirmation before deleting
  - Wired `deleteSession` mutation in `store.ts` calling the existing DELETE API endpoint
  - Passed `onDeleteSession` prop through `App.tsx` to `InterviewPrepPage`
  - Active session cannot be accidentally deleted
  - Click on card still opens the session as before

## Validation

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `python -m compileall backend`

## Screenshots

<img width="1571" height="89" alt="image" src="https://github.com/user-attachments/assets/77c07f14-3106-4454-8e70-d979a55d159b" />
<img width="817" height="381" alt="image" src="https://github.com/user-attachments/assets/068003f5-133c-48e2-9f24-0ed941487d9a" />
<img width="558" height="180" alt="image" src="https://github.com/user-attachments/assets/c7613846-0d74-4b48-8eb1-f01ce7ab1e24" />


## Risks

- No backend changes — DELETE endpoint already existed
- No DB migration needed
- No existing functionality affected