### PR TITLE
feat(job-tracker): add upcoming actions timeline widget

### DIFF
--- a/src/pages/JobTrackerPage.tsx
+++ b/src/pages/JobTrackerPage.tsx
@@ -1,12 +1,19 @@
 import { useEffect, useState, useRef } from "react";
+import {
+  startOfWeek,
+  addWeeks,
+  subWeeks,
+  format,
+  isSameDay,
+} from "date-fns";
 import { useLocation, useNavigate } from "react-router-dom";
 import {
   Briefcase,
   Plus,
   LayoutGrid,
   Table as TableIcon,
-  Check,
-  ChevronsUpDown,
+  ChevronLeft,
+  ChevronRight
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -256,6 +263,92 @@ function SortableCard({ job, onClick, isOverdue, prepScore }: { job: JobApplicat
   );
 }
 // ------------------------------
+function UpcomingActionsTimeline({
+  jobs,
+  onDateClick,
+}: {
+  jobs: JobApplication[];
+  onDateClick: (date: string) => void;
+}) {
+  const [weekStart, setWeekStart] = useState(
+    startOfWeek(new Date(), { weekStartsOn: 1 })
+  );
+
+  const days = Array.from({ length: 7 }, (_, i) => {
+    const date = new Date(weekStart);
+    date.setDate(date.getDate() + i);
+    return date;
+  });
+
+  const hasAction = (date: Date) => {
+    return jobs.some((job) => {
+      if (!job.nextActionDate) return false;
+
+      const actionDate = new Date(job.nextActionDate);
+
+      return isSameDay(actionDate, date);
+    });
+  };
+
+  return (
+    <div className="rounded-xl bg-card border border-border p-4 h-full flex flex-col justify-center">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="font-semibold">
+          Upcoming Actions
+        </h3>
+
+        <div className="flex gap-2">
+          <button
+            onClick={() =>
+              setWeekStart(subWeeks(weekStart, 1))
+            }
+          >
+            <ChevronLeft className="w-4 h-4" />
+          </button>
+
+          <button
+            onClick={() =>
+              setWeekStart(addWeeks(weekStart, 1))
+            }
+          >
+            <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      <h4 className="text-center font-semibold mb-4">
+        {format(days[0], "d MMM")} - {format(days[6], "d MMM yyyy")}
+      </h4>
+
+      <div className="grid grid-cols-7 gap-2 text-center">
+        {days.map((date) => (
+          <div key={date.toISOString()}>
+            <p className="text-xs text-muted-foreground mb-2">
+              {format(date, "EEE")}
+            </p>
+
+            <button
+              onClick={() =>
+                onDateClick(format(date, "yyyy-MM-dd"))
+              }
+              className={`
+                w-10 h-10 rounded-full
+                flex items-center justify-center
+                mx-auto transition-all
+                ${hasAction(date)
+                  ? "border-2 border-red-500 text-red-500"
+                  : "hover:bg-secondary"
+                }
+              `}
+            >
+              {format(date, "d")}
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 interface JobTrackerPageProps {
   jobs: JobApplication[];
@@ -274,6 +367,8 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
   const [savingDraft, setSavingDraft] = useState(false);
   const [deletingJob, setDeletingJob] = useState(false);
   const [jobToDelete, setJobToDelete] = useState<string | null>(null);
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const [showCalendarModal, setShowCalendarModal] = useState(false);
   const [form, setForm] = useState({ companyName: "", jobTitle: "", jobUrl: "", status: "Applied" as Status });
   const { toast } = useToast();
   const navigate = useNavigate();
@@ -542,7 +637,7 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
 
   return (
     <div className="space-y-6 animate-slide-up">
-      <div className="sticky top-0 z-30 bg-background/80 backdrop-blur-xl supports-[backdrop-filter]:bg-background/60 border-b border-border/40 pb-4 pt-2 space-y-6">
+      <div className="bg-background border-b border-border/40 pb-4 pt-2 space-y-6">
         <div className="flex items-start justify-between gap-4 flex-wrap">
           <div>
             <h1 className="text-2xl font-bold text-foreground">Job Tracker</h1>
@@ -652,23 +747,72 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
         </div>
       </div>
 
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-        <div className="rounded-xl bg-card border border-border p-3 text-center">
-          <p className="text-2xl font-bold text-foreground">{localJobs.length}</p>
-          <p className="text-xs text-muted-foreground">Total</p>
+      <div className="grid grid-cols-1 lg:grid-cols-[2fr_360px] gap-4 items-stretch">
+
+        {/* Stats */}
+        <div>
+          <div className="grid grid-cols-2 gap-3">
+
+            <div className="rounded-xl bg-card border border-border py-5 px-4 text-center">
+              <p className="text-2xl font-bold text-foreground">
+                {localJobs.length}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Total
+              </p>
+            </div>
+
+            <div className="rounded-xl bg-card border border-border py-5 px-4 text-center">
+              <p className="text-2xl font-bold text-foreground">
+                {active.length}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Active
+              </p>
+            </div>
+
+            <div className="rounded-xl bg-card border border-border py-5 px-4 text-center">
+              <p className="text-2xl font-bold text-foreground">
+                {localJobs.length
+                  ? Math.round(
+                    (interviews.length / localJobs.length) * 100
+                  )
+                  : 0}
+                %
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Interview Rate
+              </p>
+            </div>
+
+            <div className="rounded-xl bg-card border border-border py-5 px-4 text-center">
+              <p className="text-2xl font-bold text-foreground">
+                {localJobs.length
+                  ? Math.round(
+                    (offers.length / localJobs.length) * 100
+                  )
+                  : 0}
+                %
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Offer Rate
+              </p>
+            </div>
+
+          </div>
         </div>
-        <div className="rounded-xl bg-card border border-border p-3 text-center">
-          <p className="text-2xl font-bold text-foreground">{active.length}</p>
-          <p className="text-xs text-muted-foreground">Active</p>
+
+        {/* Calendar */}
+        <div className="h-full">
+          <UpcomingActionsTimeline
+            jobs={localJobs}
+            onDateClick={(date) => {
+              setSelectedDate(date);
+              setShowCalendarModal(true);
+            }}
+          />
         </div>
-        <div className="rounded-xl bg-card border border-border p-3 text-center">
-          <p className="text-2xl font-bold text-foreground">{localJobs.length ? Math.round((interviews.length / localJobs.length) * 100) : 0}%</p>
-          <p className="text-xs text-muted-foreground">Interview Rate</p>
-        </div>
-        <div className="rounded-xl bg-card border border-border p-3 text-center">
-          <p className="text-2xl font-bold text-foreground">{localJobs.length ? Math.round((offers.length / localJobs.length) * 100) : 0}%</p>
-          <p className="text-xs text-muted-foreground">Offer Rate</p>
-        </div>
+
       </div>
 
       <Sheet open={!!selectedJob} onOpenChange={(open) => !open && setSelectedJob(null)}>
@@ -894,6 +1038,67 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
           </Button>
         </div>
       )}
+
+      <Dialog
+        open={showCalendarModal}
+        onOpenChange={setShowCalendarModal}
+      >
+        <DialogContent
+          className="
+    w-[92vw]
+    max-w-md
+    max-h-[80vh]
+    p-4
+    rounded-2xl
+  "
+        >
+          <DialogHeader>
+            <DialogTitle>
+              Scheduled Actions
+            </DialogTitle>
+          </DialogHeader>
+
+          {localJobs.filter(
+            (j) => j.nextActionDate === selectedDate
+          ).length === 0 ? (
+            <p>No scheduled actions for this date.</p>
+          ) : (
+            <div className="space-y-3 max-h-[400px] overflow-y-auto pr-2
+                [scrollbar-width:thin]
+                [scrollbar-color:hsl(var(--primary))_transparent]
+                [&::-webkit-scrollbar]:w-2
+                [&::-webkit-scrollbar-track]:bg-secondary/30
+                [&::-webkit-scrollbar-track]:rounded-full
+                [&::-webkit-scrollbar-thumb]:bg-primary/70
+                [&::-webkit-scrollbar-thumb]:rounded-full
+                hover:[&::-webkit-scrollbar-thumb]:bg-primary">
+              {localJobs
+                .filter(
+                  (j) =>
+                    j.nextActionDate === selectedDate
+                )
+                .map((job) => (
+                  <div
+                    key={job.id}
+                    className="border rounded-lg p-3"
+                  >
+                    <p className="font-medium">
+                      {job.companyName}
+                    </p>
+
+                    <p className="text-sm">
+                      {job.jobTitle}
+                    </p>
+
+                    <p className="text-sm text-primary">
+                      {job.nextAction}
+                    </p>
+                  </div>
+                ))}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
 
       <AlertDialog open={!!jobToDelete} onOpenChange={(open) => !open && setJobToDelete(null)}>
         <AlertDialogContent>


### PR DESCRIPTION
## Summary

Closes #177 

- What problem does this PR solve?
- So There is a nextActionDate and nextAction that users can add to their applications but to view they have to manually click on the applicaitons to see if there is any next action and also on what date
- What changed?
- I added a next action timeline which shows a week timeline and highlights any dates that has any nextaction scheduled. Users can click on it and then check what is the action and of which job. 

## Validation

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `python -m compileall backend`

## Screenshots

<img width="1919" height="870" alt="Screenshot 2026-05-31 170738" src="https://github.com/user-attachments/assets/58e6c234-78f2-4c42-8914-1c2864dce8a0" />
<img width="1919" height="869" alt="Screenshot 2026-05-31 170747" src="https://github.com/user-attachments/assets/635593dd-86cb-41b7-9427-e27e4aebe5e0" />
<img width="1919" height="866" alt="Screenshot 2026-05-31 170755" src="https://github.com/user-attachments/assets/1a7958c6-4e1c-4b3d-891b-9bf3f9e4eef5" />
<img width="268" height="583" alt="Screenshot 2026-05-31 170810" src="https://github.com/user-attachments/assets/215ea92a-d11c-4840-89c6-32a01399ef0e" />
<img width="274" height="575" alt="Screenshot 2026-05-31 170816" src="https://github.com/user-attachments/assets/568bd32e-2f62-4cd0-aa97-b79dd1dd1ad2" />
<img width="1919" height="868" alt="Screenshot 2026-05-31 170826" src="https://github.com/user-attachments/assets/ed12f6ed-3f2c-4650-b5c8-74b84dbabd72" />


## Risks

NA

Ai Usage: AI used to write commit messgae and fix a bug where the calander height was not perfectly with the other cards. 
