### PR TITLE
feat: show personalized learning resources for skill gaps in Interview Prep

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -378,6 +378,7 @@ class GapItem(BaseModel):
     have: str
     need: str
     gapLevel: Literal["Low", "Medium", "High"]
+    resources: list[str] = Field(default_factory=list)
 
 
 class QuestionItem(BaseModel):
@@ -755,11 +756,12 @@ async def generate_session_payload(
                 "You generate structured interview preparation data. "
                 "Return valid JSON only. Do not include markdown or explanations. "
                 "Use exactly this schema: "
-                '{"gapAnalysis":[{"skill":"string","have":"string","need":"string","gapLevel":"Low|Medium|High"}],'
+                '{"gapAnalysis":[{"skill":"string","have":"string","need":"string","gapLevel":"Low|Medium|High","resources":["string"]}],'
                 '"readinessScore":0,'
                 '"questionBank":[{"question":"string","type":"behavioral|technical|situational","difficulty":"easy|medium|hard","tip":"string"}],'
                 '"roadmap":[{"day":1,"focusArea":"string","tasks":["string"]}]}. '
-                "gapAnalysis must be an array with 3 to 5 items. "
+                "gapAnalysis must be an array with 3 to 5 items. For each gapAnalysis item, "
+                "include 2-3 resource keywords (e.g., 'React', 'MDN', 'System Design', 'Python Docs'). "
                 "questionBank must be an array with 6 to 10 items. "
                 "roadmap must be an array with exactly 5 days."
             ),
@@ -797,6 +799,7 @@ async def generate_session_payload(
             "have": ["have", "current"],
             "need": ["need", "required"],
             "gapLevel": ["gaplevel", "level", "gap"],
+            "resources": ["resources", "links", "keywords"],
         }
         q_mapping = {
             "question": ["question", "text"],
@@ -811,11 +814,13 @@ async def generate_session_payload(
         }
 
         raw_gap = norm_res.get("gapanalysis", [])
-        gap_analysis = [
-            GapItem(**norm_dict(item, gap_mapping))
-            for item in raw_gap
-            if isinstance(item, dict)
-        ]
+        gap_analysis = []
+        for item in raw_gap:
+            if isinstance(item, dict):
+                normed = norm_dict(item, gap_mapping)
+                if normed.get("resources") is None:
+                    normed["resources"] = []
+                gap_analysis.append(GapItem(**normed))
 
         readiness_val = norm_res.get("readinessscore", norm_res.get("readiness", 50))
         readiness = max(0, min(100, int(readiness_val)))
@@ -844,12 +849,40 @@ async def generate_session_payload(
     scores = compute_match_score(resume_text, jd_text)
     readiness = scores["overallScore"]
     gap_analysis = [
-        GapItem(skill="React", have="Intermediate", need="Advanced", gapLevel="Medium"),
-        GapItem(skill="System Design", have="Basic", need="Advanced", gapLevel="High"),
-        GapItem(skill="TypeScript", have="Advanced", need="Advanced", gapLevel="Low"),
-        GapItem(skill="CI/CD", have="Basic", need="Intermediate", gapLevel="Medium"),
         GapItem(
-            skill="Testing", have="Intermediate", need="Advanced", gapLevel="Medium"
+            skill="React",
+            have="Intermediate",
+            need="Advanced",
+            gapLevel="Medium",
+            resources=["React", "MDN"],
+        ),
+        GapItem(
+            skill="System Design",
+            have="Basic",
+            need="Advanced",
+            gapLevel="High",
+            resources=["System Design", "MDN"],
+        ),
+        GapItem(
+            skill="TypeScript",
+            have="Advanced",
+            need="Advanced",
+            gapLevel="Low",
+            resources=["TypeScript", "MDN"],
+        ),
+        GapItem(
+            skill="CI/CD",
+            have="Basic",
+            need="Intermediate",
+            gapLevel="Medium",
+            resources=["CI/CD", "Docker"],
+        ),
+        GapItem(
+            skill="Testing",
+            have="Intermediate",
+            need="Advanced",
+            gapLevel="Medium",
+            resources=["Testing", "MDN"],
         ),
     ]
     question_bank = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,6 +116,7 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -131,6 +132,7 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -161,7 +163,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -3074,7 +3075,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3177,7 +3179,6 @@
       "integrity": "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3208,7 +3209,6 @@
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3220,7 +3220,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3278,7 +3277,6 @@
       "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.38.0",
         "@typescript-eslint/types": "8.38.0",
@@ -3634,7 +3632,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3913,7 +3910,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -4402,7 +4398,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -4499,7 +4494,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -4567,8 +4563,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -4757,7 +4752,6 @@
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5672,7 +5666,6 @@
       "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "abab": "^2.0.6",
         "acorn": "^8.8.1",
@@ -5739,7 +5732,6 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
       "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "fast-png": "^6.2.0",
@@ -5883,6 +5875,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6358,7 +6351,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6499,6 +6491,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6514,6 +6507,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6524,6 +6518,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6536,7 +6531,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6620,7 +6616,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6647,7 +6642,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6661,7 +6655,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.61.1.tgz",
       "integrity": "sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -7374,7 +7367,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -7508,7 +7500,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7631,7 +7622,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7842,7 +7832,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -70,6 +70,7 @@ export interface GapItem {
   have: string;
   need: string;
   gapLevel: "Low" | "Medium" | "High";
+  resources: string[];
 }
 
 export interface QuestionItem {

--- a/src/pages/CareerDNAPage.tsx
+++ b/src/pages/CareerDNAPage.tsx
@@ -79,13 +79,17 @@ export default function CareerDNAPage({ user, profile }: CareerDNAPageProps) {
 
         <Section title="Work History">
           <div className="space-y-3">
-            {profile.workHistory.filter((w) => w.jobTitle).map((w) => (
-              <div key={w.id} className="p-3 rounded-lg bg-secondary/30">
-                <p className="text-sm font-medium text-foreground">{w.jobTitle} at {w.company}</p>
-                <p className="text-xs text-muted-foreground">{w.from} — {w.to}</p>
-                {w.responsibilities && <p className="text-xs text-muted-foreground mt-1">{w.responsibilities}</p>}
-              </div>
-            ))}
+            {profile.workHistory.filter((w) => w.jobTitle).length === 0 ? (
+              <p className="text-sm text-muted-foreground italic">No work experience listed (Fresher)</p>
+            ) : (
+              profile.workHistory.filter((w) => w.jobTitle).map((w) => (
+                <div key={w.id} className="p-3 rounded-lg bg-secondary/30">
+                  <p className="text-sm font-medium text-foreground">{w.jobTitle} at {w.company}</p>
+                  <p className="text-xs text-muted-foreground">{w.from} — {w.to}</p>
+                  {w.responsibilities && <p className="text-xs text-muted-foreground mt-1">{w.responsibilities}</p>}
+                </div>
+              ))
+            )}
           </div>
         </Section>
 

--- a/src/pages/InterviewPrepPage.tsx
+++ b/src/pages/InterviewPrepPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, Fragment } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
 import { BookOpen, Loader2, Search, Brain, Cpu, Upload, Trash2, ChevronDown } from "lucide-react";
@@ -431,7 +431,7 @@ export default function InterviewPrepPage({
                       {activeSession.gapAnalysis.map((g, idx) => {
                         const isExpanded = !!expandedGaps[idx];
                         return (
-                          <React.Fragment key={idx}>
+                          <Fragment key={idx}>
                             <tr
                               onClick={() => toggleGap(idx)}
                               className="border-b border-border/50 hover:bg-secondary/20 transition-colors group cursor-pointer"
@@ -491,7 +491,7 @@ export default function InterviewPrepPage({
                                 </td>
                               </tr>
                             )}
-                          </React.Fragment>
+                          </Fragment>
                         );
                       })}
                     </tbody>

--- a/src/pages/InterviewPrepPage.tsx
+++ b/src/pages/InterviewPrepPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
-import { BookOpen, Loader2, Search, Brain, Cpu, Upload, Trash2 } from "lucide-react";
+import { BookOpen, Loader2, Search, Brain, Cpu, Upload, Trash2, ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   AlertDialog,
@@ -182,6 +182,50 @@ export default function InterviewPrepPage({
     Low: "text-success",
     Medium: "text-warning",
     High: "text-destructive",
+  };
+
+  const RESOURCE_MAPPING: Record<string, { label: string; url: string }> = {
+    React: { label: "React Docs", url: "https://react.dev/" },
+    "React.js": { label: "React Docs", url: "https://react.dev/" },
+    Python: { label: "Python Docs", url: "https://docs.python.org/3/" },
+    "Python Docs": { label: "Python Docs", url: "https://docs.python.org/3/" },
+    SQL: { label: "SQL MDN", url: "https://developer.mozilla.org/en-US/docs/Glossary/SQL" },
+    JavaScript: { label: "MDN JS", url: "https://developer.mozilla.org/en-US/docs/Web/JavaScript" },
+    MDN: { label: "MDN Web Docs", url: "https://developer.mozilla.org/en-US/" },
+    "System Design": { label: "System Design Primer", url: "https://github.com/donnemartin/system-design-primer" },
+    TypeScript: { label: "TypeScript Docs", url: "https://www.typescriptlang.org/docs/" },
+    Docker: { label: "Docker Docs", url: "https://docs.docker.com/" },
+    Kubernetes: { label: "Kubernetes Docs", url: "https://kubernetes.io/docs/home/" },
+    AWS: { label: "AWS Docs", url: "https://docs.aws.amazon.com/" },
+    "Node.js": { label: "Node.js Docs", url: "https://nodejs.org/docs/" },
+    FastAPI: { label: "FastAPI Docs", url: "https://fastapi.tiangolo.com/" },
+    Go: { label: "Go Docs", url: "https://go.dev/doc/" },
+    Java: { label: "Java Docs", url: "https://docs.oracle.com/en/java/" },
+    "C++": { label: "C++ Reference", url: "https://en.cppreference.com/w/" },
+    "C#": { label: "C# Docs", url: "https://learn.microsoft.com/en-us/dotnet/csharp/" },
+    Spring: { label: "Spring Docs", url: "https://spring.io/projects/spring-framework" },
+    Django: { label: "Django Docs", url: "https://docs.djangoproject.com/" },
+    Flask: { label: "Flask Docs", url: "https://flask.palletsprojects.com/" },
+    Redux: { label: "Redux Docs", url: "https://redux.js.org/" },
+    GraphQL: { label: "GraphQL Docs", url: "https://graphql.org/learn/" },
+    Tailwind: { label: "Tailwind Docs", url: "https://tailwindcss.com/docs" },
+    CSS: { label: "MDN CSS", url: "https://developer.mozilla.org/en-US/docs/Web/CSS" },
+    HTML: { label: "MDN HTML", url: "https://developer.mozilla.org/en-US/docs/Web/HTML" },
+    Testing: { label: "Testing Library", url: "https://testing-library.com/docs/" },
+    "CI/CD": { label: "CI/CD Guide", url: "https://resources.github.com/ci-cd/" },
+    Git: { label: "Git Docs", url: "https://git-scm.com/doc" },
+    PostgreSQL: { label: "PostgreSQL Docs", url: "https://www.postgresql.org/docs/" },
+    MongoDB: { label: "MongoDB Docs", url: "https://www.mongodb.com/docs/" },
+    Redis: { label: "Redis Docs", url: "https://redis.io/docs/" },
+  };
+
+  const [expandedGaps, setExpandedGaps] = useState<Record<number, boolean>>({});
+
+  const toggleGap = (idx: number) => {
+    setExpandedGaps((prev) => ({
+      ...prev,
+      [idx]: !prev[idx],
+    }));
   };
 
   const filteredQuestions = activeSession?.questionBank.filter((q) => {
@@ -372,7 +416,7 @@ export default function InterviewPrepPage({
                   <table className="w-full text-sm">
                     <thead>
                       <tr className="border-b border-border">
-                        <th className="text-left py-3 text-muted-foreground font-medium">Skill</th>
+                        <th className="text-left py-3 text-muted-foreground font-medium pl-4">Skill</th>
                         <th className="text-left py-3 text-muted-foreground font-medium">
                           {activeSession.isEstimated && !activeSession.resumeText && !activeSession.jdText
                             ? "You Have (Estimated)"
@@ -380,17 +424,76 @@ export default function InterviewPrepPage({
                         </th>
                         <th className="text-left py-3 text-muted-foreground font-medium">They Need</th>
                         <th className="text-left py-3 text-muted-foreground font-medium">Gap Level</th>
+                        <th className="w-10"></th>
                       </tr>
                     </thead>
                     <tbody>
-                      {activeSession.gapAnalysis.map((g) => (
-                        <tr key={g.skill} className="border-b border-border/50">
-                          <td className="py-3 font-medium text-foreground">{g.skill}</td>
-                          <td className="py-3 text-muted-foreground">{g.have}</td>
-                          <td className="py-3 text-muted-foreground">{g.need}</td>
-                          <td className={`py-3 font-medium ${gapColor[g.gapLevel]}`}>{g.gapLevel}</td>
-                        </tr>
-                      ))}
+                      {activeSession.gapAnalysis.map((g, idx) => {
+                        const isExpanded = !!expandedGaps[idx];
+                        return (
+                          <React.Fragment key={idx}>
+                            <tr
+                              onClick={() => toggleGap(idx)}
+                              className="border-b border-border/50 hover:bg-secondary/20 transition-colors group cursor-pointer"
+                            >
+                              <td className="py-4 pl-4 font-medium text-foreground">
+                                <div className="flex items-center gap-2">
+                                  <ChevronDown className={`w-4 h-4 transition-transform duration-200 ${isExpanded ? "rotate-180" : ""}`} />
+                                  {g.skill}
+                                </div>
+                              </td>
+                              <td className="py-4 text-muted-foreground">{g.have}</td>
+                              <td className="py-4 text-muted-foreground">{g.need}</td>
+                              <td className={`py-4 font-medium ${gapColor[g.gapLevel]}`}>{g.gapLevel}</td>
+                              <td className="py-4 pr-4"></td>
+                            </tr>
+                            {isExpanded && (
+                              <tr>
+                                <td colSpan={5} className="p-0">
+                                  <div className="bg-secondary/30 p-4 rounded-b-xl border-x border-b border-border/50 mx-2 mb-2">
+                                    <h4 className="text-xs font-semibold text-foreground uppercase tracking-wider mb-3">Recommended Learning Resources</h4>
+                                    <div className="flex flex-wrap gap-3">
+                                      {g.resources && g.resources.length > 0 ? (
+                                        g.resources.map((resKey, rIdx) => {
+                                          const resource = RESOURCE_MAPPING[resKey];
+                                          if (resource) {
+                                            return (
+                                              <a
+                                                key={rIdx}
+                                                href={resource.url}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-background border border-border hover:border-primary/50 text-sm text-primary transition-all shadow-sm"
+                                              >
+                                                <BookOpen className="w-3.5 h-3.5" />
+                                                {resource.label}
+                                              </a>
+                                            );
+                                          }
+                                          return (
+                                            <a
+                                              key={rIdx}
+                                              href={`https://www.google.com/search?q=${encodeURIComponent(resKey + " documentation")}`}
+                                              target="_blank"
+                                              rel="noopener noreferrer"
+                                              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-background border border-border hover:border-primary/50 text-sm text-primary transition-all shadow-sm"
+                                            >
+                                              <Search className="w-3.5 h-3.5" />
+                                              {resKey}
+                                            </a>
+                                          );
+                                        })
+                                      ) : (
+                                        <p className="text-xs text-muted-foreground italic">No specific resources found. Try searching for "{g.skill} docs".</p>
+                                      )}
+                                    </div>
+                                  </div>
+                                </td>
+                              </tr>
+                            )}
+                          </React.Fragment>
+                        );
+                      })}
                     </tbody>
                   </table>
                 </div>

--- a/src/pages/JobTrackerPage.tsx
+++ b/src/pages/JobTrackerPage.tsx
@@ -374,23 +374,10 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [showCalendarModal, setShowCalendarModal] = useState(false);
   const [form, setForm] = useState({ companyName: "", jobTitle: "", jobUrl: "", status: "Applied" as Status });
-  const [searchQuery, setSearchQuery] = useState("");
-  const [statusFilter, setStatusFilter] = useState("all");
 
   const { toast } = useToast();
   const navigate = useNavigate();
   const location = useLocation();
-
-  const filteredJobs = localJobs.filter((job) => {
-    const matchesSearch =
-      job.companyName.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      job.jobTitle.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      (job.location && job.location.toLowerCase().includes(searchQuery.toLowerCase()));
-    
-    const matchesStatus = statusFilter === "all" || job.status === statusFilter;
-    
-    return matchesSearch && matchesStatus;
-  });
 
   // Handle route state for auto-selection
   useEffect(() => {
@@ -432,7 +419,6 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
   };
 
   // Optimistic jobs state for DnD
-  const [jobRoleOpen, setJobRoleOpen] = useState(false);
   const [localJobs, setLocalJobs] = useState<JobApplication[]>(jobs);
   const localJobsRef = useRef(jobs);
   const [activeJob, setActiveJob] = useState<JobApplication | null>(null);
@@ -446,7 +432,8 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
     const matchesSearch =
       !term ||
       j.companyName.toLowerCase().includes(term) ||
-      j.jobTitle.toLowerCase().includes(term);
+      j.jobTitle.toLowerCase().includes(term) ||
+      (j.location && j.location.toLowerCase().includes(term));
     const matchesStatus = statusFilter === "All" || j.status === statusFilter;
     return matchesSearch && matchesStatus;
   });
@@ -691,17 +678,15 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
             </p>
           </div>
 
-<<<<<<< HEAD
-          <div className="flex items-center gap-2 flex-wrap">
-            {/* Search bar (issue #188) */}
-            <div className="relative">
-              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground pointer-events-none" />
+          <div className="flex items-center gap-3 flex-wrap">
+            <div className="relative w-48 sm:w-64">
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
               <Input
-                id="job-tracker-search"
-                placeholder="Search company or role…"
+                type="text"
+                placeholder="Search jobs or companies..."
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
-                className="pl-8 h-8 w-44 text-xs bg-secondary border-border"
+                className="pl-9 h-9 bg-secondary/50 border-border text-sm"
               />
               {searchTerm && (
                 <button
@@ -709,49 +694,16 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
                   className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                   aria-label="Clear search"
                 >
-                  <X className="w-3 h-3" />
+                  <X className="w-4 h-4" />
                 </button>
               )}
             </div>
-            {/* Status filter */}
             <Select value={statusFilter} onValueChange={(v) => setStatusFilter(v as Status | "All")}>
-              <SelectTrigger id="job-tracker-status-filter" className="h-8 w-32 text-xs bg-secondary border-border">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="All">All statuses</SelectItem>
-                {STATUSES.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}
-              </SelectContent>
-            </Select>
-            {hasActiveFilter && (
-              <button
-                onClick={() => { setSearchTerm(""); setStatusFilter("All"); }}
-                className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
-                aria-label="Clear all filters"
-              >
-                Clear
-              </button>
-            )}
-            <div className="flex bg-secondary rounded-lg p-0.5">
-              <button onClick={() => setView("kanban")} className={`px-3 py-1.5 rounded-md text-sm transition-colors ${view === "kanban" ? "bg-card text-foreground shadow-sm" : "text-muted-foreground"}`}>
-=======
-          <div className="flex items-center gap-3 flex-wrap">
-            <div className="relative w-48 sm:w-64">
-              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-              <Input
-                type="text"
-                placeholder="Search jobs or companies..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="pl-9 h-9 bg-secondary/50 border-border"
-              />
-            </div>
-            <Select value={statusFilter} onValueChange={setStatusFilter}>
-              <SelectTrigger className="w-32 h-9 bg-secondary/50 border-border">
+              <SelectTrigger className="w-32 h-9 bg-secondary/50 border-border text-sm">
                 <SelectValue placeholder="All Statuses" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">All Statuses</SelectItem>
+                <SelectItem value="All">All Statuses</SelectItem>
                 {STATUSES.map((s) => (
                   <SelectItem key={s} value={s}>
                     {s}
@@ -762,7 +714,6 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
 
             <div className="flex bg-secondary rounded-lg p-0.5 h-9 items-center">
               <button onClick={() => setView("kanban")} className={`px-3 py-1.5 rounded-md text-sm transition-colors h-8 ${view === "kanban" ? "bg-card text-foreground shadow-sm" : "text-muted-foreground"}`}>
->>>>>>> e9fc0f7 (feat: add search & filter to Job Tracker and fresher onboarding toggle)
                 <LayoutGrid className="w-4 h-4" />
               </button>
               <button onClick={() => setView("table")} className={`px-3 py-1.5 rounded-md text-sm transition-colors h-8 ${view === "table" ? "bg-card text-foreground shadow-sm" : "text-muted-foreground"}`}>
@@ -1136,11 +1087,7 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
                 {filteredJobs.length === 0 ? (
                   <tr>
                     <td colSpan={5} className="py-12 text-center text-muted-foreground">
-<<<<<<< HEAD
-                      {hasActiveFilter ? "No applications match your filters" : "No applications yet"}
-=======
-                      {localJobs.length === 0 ? "No applications yet" : "No matching applications found"}
->>>>>>> e9fc0f7 (feat: add search & filter to Job Tracker and fresher onboarding toggle)
+                      {hasActiveFilter ? "No matching applications found" : "No applications tracked yet"}
                     </td>
                   </tr>
                 ) : (
@@ -1185,7 +1132,7 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
         </div>
       )}
 
-      {localJobs.length === 0 && (
+      {localJobs.length === 0 && !hasActiveFilter && (
         <div className="bg-card border border-border rounded-2xl p-12 text-center shadow-card">
           <Briefcase className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
           <h3 className="text-lg font-semibold text-foreground mb-1">No applications tracked</h3>

--- a/src/pages/JobTrackerPage.tsx
+++ b/src/pages/JobTrackerPage.tsx
@@ -16,6 +16,8 @@ import {
   ChevronRight,
   Search,
   X,
+  Check,
+  ChevronsUpDown,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -372,9 +374,23 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [showCalendarModal, setShowCalendarModal] = useState(false);
   const [form, setForm] = useState({ companyName: "", jobTitle: "", jobUrl: "", status: "Applied" as Status });
+  const [searchQuery, setSearchQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState("all");
+
   const { toast } = useToast();
   const navigate = useNavigate();
   const location = useLocation();
+
+  const filteredJobs = localJobs.filter((job) => {
+    const matchesSearch =
+      job.companyName.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      job.jobTitle.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      (job.location && job.location.toLowerCase().includes(searchQuery.toLowerCase()));
+    
+    const matchesStatus = statusFilter === "all" || job.status === statusFilter;
+    
+    return matchesSearch && matchesStatus;
+  });
 
   // Handle route state for auto-selection
   useEffect(() => {
@@ -675,6 +691,7 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
             </p>
           </div>
 
+<<<<<<< HEAD
           <div className="flex items-center gap-2 flex-wrap">
             {/* Search bar (issue #188) */}
             <div className="relative">
@@ -717,9 +734,38 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
             )}
             <div className="flex bg-secondary rounded-lg p-0.5">
               <button onClick={() => setView("kanban")} className={`px-3 py-1.5 rounded-md text-sm transition-colors ${view === "kanban" ? "bg-card text-foreground shadow-sm" : "text-muted-foreground"}`}>
+=======
+          <div className="flex items-center gap-3 flex-wrap">
+            <div className="relative w-48 sm:w-64">
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                type="text"
+                placeholder="Search jobs or companies..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-9 h-9 bg-secondary/50 border-border"
+              />
+            </div>
+            <Select value={statusFilter} onValueChange={setStatusFilter}>
+              <SelectTrigger className="w-32 h-9 bg-secondary/50 border-border">
+                <SelectValue placeholder="All Statuses" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Statuses</SelectItem>
+                {STATUSES.map((s) => (
+                  <SelectItem key={s} value={s}>
+                    {s}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <div className="flex bg-secondary rounded-lg p-0.5 h-9 items-center">
+              <button onClick={() => setView("kanban")} className={`px-3 py-1.5 rounded-md text-sm transition-colors h-8 ${view === "kanban" ? "bg-card text-foreground shadow-sm" : "text-muted-foreground"}`}>
+>>>>>>> e9fc0f7 (feat: add search & filter to Job Tracker and fresher onboarding toggle)
                 <LayoutGrid className="w-4 h-4" />
               </button>
-              <button onClick={() => setView("table")} className={`px-3 py-1.5 rounded-md text-sm transition-colors ${view === "table" ? "bg-card text-foreground shadow-sm" : "text-muted-foreground"}`}>
+              <button onClick={() => setView("table")} className={`px-3 py-1.5 rounded-md text-sm transition-colors h-8 ${view === "table" ? "bg-card text-foreground shadow-sm" : "text-muted-foreground"}`}>
                 <TableIcon className="w-4 h-4" />
               </button>
             </div>
@@ -1090,7 +1136,11 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
                 {filteredJobs.length === 0 ? (
                   <tr>
                     <td colSpan={5} className="py-12 text-center text-muted-foreground">
+<<<<<<< HEAD
                       {hasActiveFilter ? "No applications match your filters" : "No applications yet"}
+=======
+                      {localJobs.length === 0 ? "No applications yet" : "No matching applications found"}
+>>>>>>> e9fc0f7 (feat: add search & filter to Job Tracker and fresher onboarding toggle)
                     </td>
                   </tr>
                 ) : (

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -183,7 +183,6 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
   const [softSkills, setSoftSkills] = useState<string[]>([]);
   const [fears, setFears] = useState<string[]>([]);
   const [fearNotes, setFearNotes] = useState("");
-  const [isFresher, setIsFresher] = useState(false);
 
   useEffect(() => {
     if (!profile) {
@@ -243,12 +242,8 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
         return null;
       }
       case 2: {
-<<<<<<< HEAD
         if (isFresher) return null; // freshers skip work validation
 
-=======
-        if (isFresher) return null;
->>>>>>> e9fc0f7 (feat: add search & filter to Job Tracker and fresher onboarding toggle)
         let filledCount = 0;
         const currentYear = new Date().getFullYear();
 
@@ -437,13 +432,18 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
 
               {step === 2 && (
                 <>
-<<<<<<< HEAD
-                  {/* Fresher toggle (issue #61) */}
                   <div className="flex items-start gap-3 p-3 rounded-xl bg-primary/5 border border-primary/20">
                     <Checkbox
                       id="is-fresher-toggle"
                       checked={isFresher}
-                      onCheckedChange={(checked) => setIsFresher(!!checked)}
+                      onCheckedChange={(checked) => {
+                        setIsFresher(!!checked);
+                        if (checked) {
+                          setWorkHistory([]);
+                        } else {
+                          setWorkHistory([emptyWorkEntry()]);
+                        }
+                      }}
                       className="mt-0.5"
                     />
                     <div>
@@ -459,25 +459,6 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
                     </div>
                   </div>
 
-=======
-                  <div className="flex items-center gap-2 mb-4 bg-secondary/20 p-3 rounded-xl border border-border/50">
-                    <Checkbox
-                      id="fresher-toggle"
-                      checked={isFresher}
-                      onCheckedChange={(checked) => {
-                        setIsFresher(!!checked);
-                        if (checked) {
-                          setWorkHistory([]);
-                        } else {
-                          setWorkHistory([emptyWorkEntry()]);
-                        }
-                      }}
-                    />
-                    <Label htmlFor="fresher-toggle" className="cursor-pointer text-sm font-medium text-foreground">
-                      I am a fresher (No professional work experience)
-                    </Label>
-                  </div>
->>>>>>> e9fc0f7 (feat: add search & filter to Job Tracker and fresher onboarding toggle)
                   {!isFresher && (
                     <>
                       {workHistory.map((entry, idx) => (

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -183,6 +183,7 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
   const [softSkills, setSoftSkills] = useState<string[]>([]);
   const [fears, setFears] = useState<string[]>([]);
   const [fearNotes, setFearNotes] = useState("");
+  const [isFresher, setIsFresher] = useState(false);
 
   useEffect(() => {
     if (!profile) {
@@ -196,7 +197,9 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
     setGraduationYear(profile.graduationYear);
     setCoursework(profile.coursework);
     setCertifications(profile.certifications);
-    setWorkHistory(profile.workHistory.length > 0 ? profile.workHistory : [emptyWorkEntry()]);
+    const fresher = profile.workHistory.length === 0;
+    setIsFresher(fresher);
+    setWorkHistory(fresher ? [] : (profile.workHistory.length > 0 ? profile.workHistory : [emptyWorkEntry()]));
     setTechnicalSkills(profile.technicalSkills);
     setSoftSkills(profile.softSkills);
     setFears(profile.interviewFears);
@@ -240,8 +243,12 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
         return null;
       }
       case 2: {
+<<<<<<< HEAD
         if (isFresher) return null; // freshers skip work validation
 
+=======
+        if (isFresher) return null;
+>>>>>>> e9fc0f7 (feat: add search & filter to Job Tracker and fresher onboarding toggle)
         let filledCount = 0;
         const currentYear = new Date().getFullYear();
 
@@ -430,6 +437,7 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
 
               {step === 2 && (
                 <>
+<<<<<<< HEAD
                   {/* Fresher toggle (issue #61) */}
                   <div className="flex items-start gap-3 p-3 rounded-xl bg-primary/5 border border-primary/20">
                     <Checkbox
@@ -451,6 +459,25 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
                     </div>
                   </div>
 
+=======
+                  <div className="flex items-center gap-2 mb-4 bg-secondary/20 p-3 rounded-xl border border-border/50">
+                    <Checkbox
+                      id="fresher-toggle"
+                      checked={isFresher}
+                      onCheckedChange={(checked) => {
+                        setIsFresher(!!checked);
+                        if (checked) {
+                          setWorkHistory([]);
+                        } else {
+                          setWorkHistory([emptyWorkEntry()]);
+                        }
+                      }}
+                    />
+                    <Label htmlFor="fresher-toggle" className="cursor-pointer text-sm font-medium text-foreground">
+                      I am a fresher (No professional work experience)
+                    </Label>
+                  </div>
+>>>>>>> e9fc0f7 (feat: add search & filter to Job Tracker and fresher onboarding toggle)
                   {!isFresher && (
                     <>
                       {workHistory.map((entry, idx) => (


### PR DESCRIPTION
This PR implements personalized learning resources for skill gaps in the Interview Prep page.

### Technical Details:
- **Backend Updates**: Modified generate_session_payload() in ackend/app/main.py to include a esources field in the OpenRouter prompt. The AI now returns 2-3 resource keywords for each skill gap.
- **Data Models**: Updated GapItem in both backend (Pydantic) and frontend (TypeScript) to include the esources field.
- **Frontend Mapping**: Implemented a RESOURCE_MAPPING in src/pages/InterviewPrepPage.tsx that translates keywords into official documentation URLs (e.g., MDN, React Docs, Python Docs).
- **Expandable UI**: Refactored the Skill Gap Analysis table to use an expandable row design. Users can now click on a skill to reveal recommended learning resources.
- **Fallbacks**: Added fallback resources to the backend's default payload to ensure a good user experience even when the AI is unavailable.

Fixes #190