### PR TITLE
feat: add search/filter to Job Tracker (#188) and fresher toggle to Onboarding (#61)

### DIFF
--- a/src/pages/JobTrackerPage.tsx
+++ b/src/pages/JobTrackerPage.tsx
@@ -13,7 +13,9 @@ import {
   LayoutGrid,
   Table as TableIcon,
   ChevronLeft,
-  ChevronRight
+  ChevronRight,
+  Search,
+  X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -419,6 +421,22 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
   const localJobsRef = useRef(jobs);
   const [activeJob, setActiveJob] = useState<JobApplication | null>(null);
 
+  // Search & filter state (issue #188)
+  const [searchTerm, setSearchTerm] = useState("");
+  const [statusFilter, setStatusFilter] = useState<Status | "All">("All");
+
+  const filteredJobs = localJobs.filter((j) => {
+    const term = searchTerm.toLowerCase();
+    const matchesSearch =
+      !term ||
+      j.companyName.toLowerCase().includes(term) ||
+      j.jobTitle.toLowerCase().includes(term);
+    const matchesStatus = statusFilter === "All" || j.status === statusFilter;
+    return matchesSearch && matchesStatus;
+  });
+
+  const hasActiveFilter = searchTerm !== "" || statusFilter !== "All";
+
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
@@ -646,7 +664,46 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
             </p>
           </div>
 
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 flex-wrap">
+            {/* Search bar (issue #188) */}
+            <div className="relative">
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground pointer-events-none" />
+              <Input
+                id="job-tracker-search"
+                placeholder="Search company or role…"
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="pl-8 h-8 w-44 text-xs bg-secondary border-border"
+              />
+              {searchTerm && (
+                <button
+                  onClick={() => setSearchTerm("")}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                  aria-label="Clear search"
+                >
+                  <X className="w-3 h-3" />
+                </button>
+              )}
+            </div>
+            {/* Status filter */}
+            <Select value={statusFilter} onValueChange={(v) => setStatusFilter(v as Status | "All")}>
+              <SelectTrigger id="job-tracker-status-filter" className="h-8 w-32 text-xs bg-secondary border-border">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="All">All statuses</SelectItem>
+                {STATUSES.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}
+              </SelectContent>
+            </Select>
+            {hasActiveFilter && (
+              <button
+                onClick={() => { setSearchTerm(""); setStatusFilter("All"); }}
+                className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
+                aria-label="Clear all filters"
+              >
+                Clear
+              </button>
+            )}
             <div className="flex bg-secondary rounded-lg p-0.5">
               <button onClick={() => setView("kanban")} className={`px-3 py-1.5 rounded-md text-sm transition-colors ${view === "kanban" ? "bg-card text-foreground shadow-sm" : "text-muted-foreground"}`}>
                 <LayoutGrid className="w-4 h-4" />
@@ -922,7 +979,7 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
         >
           <div className="flex gap-4 overflow-x-auto pb-4 max-h-[calc(100vh-320px)] [scrollbar-width:thin] [scrollbar-color:hsl(var(--primary))_transparent] [&::-webkit-scrollbar]:h-2 [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-secondary/30 [&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-thumb]:bg-primary/70 [&::-webkit-scrollbar-thumb]:rounded-full hover:[&::-webkit-scrollbar-thumb]:bg-primary">
             {kanbanColumns.map((status) => {
-              const colJobs = localJobs.filter((j) => j.status === status);
+              const colJobs = filteredJobs.filter((j) => j.status === status);
               return (
                 <SortableColumn key={status} id={status}>
                   <div className="flex items-center gap-2 mb-3">
@@ -982,12 +1039,14 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
                 </tr>
               </thead>
               <tbody>
-                {localJobs.length === 0 ? (
+                {filteredJobs.length === 0 ? (
                   <tr>
-                    <td colSpan={5} className="py-12 text-center text-muted-foreground">No applications yet</td>
+                    <td colSpan={5} className="py-12 text-center text-muted-foreground">
+                      {hasActiveFilter ? "No applications match your filters" : "No applications yet"}
+                    </td>
                   </tr>
                 ) : (
-                  localJobs.map((job) => (
+                  filteredJobs.map((job) => (
                     <tr key={job.id} className="border-b border-border/50 hover:bg-secondary/20 cursor-pointer" onClick={() => setSelectedJob(job)}>
                       <td className="py-3 px-4 font-medium text-foreground max-w-[220px] truncate">
                         <div className="flex items-center gap-2">

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -176,6 +176,7 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
   const [coursework, setCoursework] = useState("");
   const [certifications, setCertifications] = useState<string[]>([]);
   const [workHistory, setWorkHistory] = useState<WorkEntry[]>([emptyWorkEntry()]);
+  const [isFresher, setIsFresher] = useState(false);
   const [technicalSkills, setTechnicalSkills] = useState<SkillEntry[]>([]);
   const [techQuery, setTechQuery] = useState("");
   const [isTechOpen, setIsTechOpen] = useState(false);
@@ -239,6 +240,8 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
         return null;
       }
       case 2: {
+        if (isFresher) return null; // freshers skip work validation
+
         let filledCount = 0;
         const currentYear = new Date().getFullYear();
 
@@ -326,7 +329,7 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
       graduationYear,
       coursework,
       certifications,
-      workHistory,
+      workHistory: isFresher ? [] : workHistory,
       technicalSkills,
       softSkills,
       interviewFears: fears,
@@ -427,28 +430,53 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
 
               {step === 2 && (
                 <>
-                  {workHistory.map((entry, idx) => (
-                    <div key={entry.id} className="p-4 rounded-xl bg-secondary/30 border border-border space-y-3">
-                      <div className="flex items-center justify-between">
-                        <span className="text-sm font-medium text-muted-foreground">Experience {idx + 1}</span>
-                        {workHistory.length > 1 && (
-                          <Button variant="ghost" size="sm" onClick={() => removeWorkEntry(entry.id)}>
-                            <Trash2 className="w-4 h-4 text-destructive" />
-                          </Button>
-                        )}
-                      </div>
-                      <div className="grid grid-cols-2 gap-3">
-                        <SearchableInput options={PREDEFINED_ROLES} placeholder="Job Title" value={entry.jobTitle} onChange={(v) => updateWork(entry.id, "jobTitle", v)} className="bg-secondary/50" />
-                        <SearchableInput options={PREDEFINED_COMPANIES} placeholder="Company" value={entry.company} onChange={(v) => updateWork(entry.id, "company", v)} className="bg-secondary/50" />
-                        <Input placeholder="From (e.g. 2020)" value={entry.from} onChange={(e) => updateWork(entry.id, "from", e.target.value)} className="bg-secondary/50" />
-                        <Input placeholder="To (e.g. 2023 or Present)" value={entry.to} onChange={(e) => updateWork(entry.id, "to", e.target.value)} className="bg-secondary/50" />
-                      </div>
-                      <Textarea placeholder="Key responsibilities..." value={entry.responsibilities} onChange={(e) => updateWork(entry.id, "responsibilities", e.target.value)} className="bg-secondary/50" />
+                  {/* Fresher toggle (issue #61) */}
+                  <div className="flex items-start gap-3 p-3 rounded-xl bg-primary/5 border border-primary/20">
+                    <Checkbox
+                      id="is-fresher-toggle"
+                      checked={isFresher}
+                      onCheckedChange={(checked) => setIsFresher(!!checked)}
+                      className="mt-0.5"
+                    />
+                    <div>
+                      <label
+                        htmlFor="is-fresher-toggle"
+                        className="text-sm font-medium text-foreground cursor-pointer"
+                      >
+                        I am a Fresher / No prior work experience
+                      </label>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        Check this to skip the work experience section.
+                      </p>
                     </div>
-                  ))}
-                  <Button variant="outline" onClick={addWorkEntry} className="w-full border-dashed">
-                    <Plus className="w-4 h-4 mr-2" /> Add Experience
-                  </Button>
+                  </div>
+
+                  {!isFresher && (
+                    <>
+                      {workHistory.map((entry, idx) => (
+                        <div key={entry.id} className="p-4 rounded-xl bg-secondary/30 border border-border space-y-3">
+                          <div className="flex items-center justify-between">
+                            <span className="text-sm font-medium text-muted-foreground">Experience {idx + 1}</span>
+                            {workHistory.length > 1 && (
+                              <Button variant="ghost" size="sm" onClick={() => removeWorkEntry(entry.id)}>
+                                <Trash2 className="w-4 h-4 text-destructive" />
+                              </Button>
+                            )}
+                          </div>
+                          <div className="grid grid-cols-2 gap-3">
+                            <SearchableInput options={PREDEFINED_ROLES} placeholder="Job Title" value={entry.jobTitle} onChange={(v) => updateWork(entry.id, "jobTitle", v)} className="bg-secondary/50" />
+                            <SearchableInput options={PREDEFINED_COMPANIES} placeholder="Company" value={entry.company} onChange={(v) => updateWork(entry.id, "company", v)} className="bg-secondary/50" />
+                            <Input placeholder="From (e.g. 2020)" value={entry.from} onChange={(e) => updateWork(entry.id, "from", e.target.value)} className="bg-secondary/50" />
+                            <Input placeholder="To (e.g. 2023 or Present)" value={entry.to} onChange={(e) => updateWork(entry.id, "to", e.target.value)} className="bg-secondary/50" />
+                          </div>
+                          <Textarea placeholder="Key responsibilities..." value={entry.responsibilities} onChange={(e) => updateWork(entry.id, "responsibilities", e.target.value)} className="bg-secondary/50" />
+                        </div>
+                      ))}
+                      <Button variant="outline" onClick={addWorkEntry} className="w-full border-dashed">
+                        <Plus className="w-4 h-4 mr-2" /> Add Experience
+                      </Button>
+                    </>
+                  )}
                 </>
               )}
 


### PR DESCRIPTION
## Summary

Addresses two assigned feature requests:

### Closes #188 — Search & Filter for Job Tracker

Adds real-time search and status filtering to `JobTrackerPage.tsx` (frontend-only, no backend changes):

- **Search bar**: Filters by company name or job title as you type, with an inline clear (×) button
- **Status filter dropdown**: All / Applied / Screening / Interview / Offer / Rejected / Ghosted
- **Works in both views**: Kanban columns and Table view both reflect the filtered results
- **Clear button**: Visible when any filter is active; resets both with one click
- **Smart empty state**: Shows "No applications match your filters" when filtering, vs the normal empty CTA when no applications exist

### Closes #61 — "I am a Fresher" Toggle in Onboarding

Adds a checkbox toggle to the Work Experience step in `OnboardingPage.tsx`:

- **Checkbox at step top**: "I am a Fresher / No prior work experience"
- **Collapses form fields**: Checking it hides all experience inputs
- **Bypasses validation**: The strict "at least one work entry" requirement is skipped for freshers
- **Clean save**: Persists an empty `workHistory: []` when the fresher toggle is active

## Changes

| File | What changed |
|------|-------------|
| `src/pages/JobTrackerPage.tsx` | Added `searchTerm`, `statusFilter`, `filteredJobs`, search bar UI, status dropdown, clear button |
| `src/pages/OnboardingPage.tsx` | Added `isFresher` state, Checkbox toggle UI in step 2, updated `validateStep` case 2 and `handleComplete` |

## Testing

- [x] TypeScript type check passes (`tsc --noEmit` — 0 errors)
- [x] Search filters update instantly in Kanban and Table views
- [x] Status filter works alongside search (AND logic)
- [x] Fresher toggle collapses work inputs and allows advancing past step 2
- [x] Non-fresher path unchanged — validation still enforces at least one entry
- [x] Works on desktop and mobile layouts
