### PR TITLE
fix: add max_length validation to jdText and resumeText (#194)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -411,8 +411,8 @@ class InterviewSession(BaseModel):
 class CreateInterviewSessionRequest(BaseModel):
     jobTitle: str
     company: str
-    jdText: str = ""
-    resumeText: str = ""
+    jdText: str = Field(default="", max_length=15000)
+    resumeText: str = Field(default="", max_length=8000)
 
     @field_validator("jobTitle", "company", mode="after")
     @classmethod
@@ -1503,6 +1503,7 @@ def get_session(
     "/api/users/{user_id}/sessions",
     response_model=InterviewSession,
     status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(validate_payload_size)],
 )
 async def create_session(
     user_id: str,

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -470,6 +470,49 @@ class PrepIQApiTestCase(unittest.TestCase):
         )
         self.assertEqual(res_bad_diff.status_code, 422)
 
+    def test_jd_text_too_long_returns_422(self) -> None:
+        user_id, headers = self.create_account()
+        res = self.client.post(
+            f"/api/users/{user_id}/sessions",
+            headers=headers,
+            json={
+                "jobTitle": "Engineer",
+                "company": "ACME",
+                "jdText": "a" * 15001,
+                "resumeText": "Valid resume text",
+            },
+        )
+        self.assertEqual(res.status_code, 422)
+        self.assertEqual(res.json()["detail"][0]["loc"], ["body", "jdText"])
+
+    def test_resume_text_too_long_returns_422(self) -> None:
+        user_id, headers = self.create_account()
+        res = self.client.post(
+            f"/api/users/{user_id}/sessions",
+            headers=headers,
+            json={
+                "jobTitle": "Engineer",
+                "company": "ACME",
+                "jdText": "Valid job description",
+                "resumeText": "a" * 8001,
+            },
+        )
+        self.assertEqual(res.status_code, 422)
+        self.assertEqual(res.json()["detail"][0]["loc"], ["body", "resumeText"])
+
+    def test_valid_session_lengths_accepted(self) -> None:
+        user_id, headers = self.create_account()
+        res = self.client.post(
+            f"/api/users/{user_id}/sessions",
+            headers=headers,
+            json={
+                "jobTitle": "Engineer",
+                "company": "ACME",
+                "jdText": "We are looking for a backend engineer.",
+                "resumeText": "5 years of Python experience.",
+            },
+        )
+        self.assertNotEqual(res.status_code, 422)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #194

## Changes
- Added `Field(max_length=15000)` to `jdText` in `CreateInterviewSessionRequest`
- Added `Field(max_length=8000)` to `resumeText` in `CreateInterviewSessionRequest`  
- Applied existing `validate_payload_size` dependency to the sessions endpoint
- Added tests in `backend/tests/test_api.py` for oversized inputs

## Why
Unbounded text fields were being passed directly to the LLM API,
causing inflated costs and DoS risk.