### PR TITLE
: add PYTHONUNBUFFERED=1 to Dockerfile.backend for real…

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,5 +1,7 @@
 FROM python:3.10-slim
 
+ENV PYTHONUNBUFFERED=1
+
 WORKDIR /app
 
 COPY backend/requirements.txt /app/backend/requirements.txt


### PR DESCRIPTION
### Description
Currently, the backend container relies on Python's default behavior, which buffers the standard output and standard error streams. In containerized environments, this buffering can cause critical logs to be delayed or entirely lost if the FastAPI application crashes abruptly, severely hindering real-time debugging and observability.

This PR introduces the `PYTHONUNBUFFERED=1` environment variable to the backend Docker setup, forcing the stdout and stderr streams to be unbuffered and ensuring all logs are immediately flushed to the container's output stream.

### Related Issue
* Closes #215 

### Changes Made
* Added `ENV PYTHONUNBUFFERED=1` to `backend/Dockerfile.backend` (or the root backend Dockerfile) to configure Python logging for production/Docker environments.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🔧 Chore / Configuration (non-breaking update to build scripts, Docker, or dependencies)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have tested that the Docker container still builds successfully locally.
- [x] I am contributing this under the **GirlScript Summer of Code (GSSoc)** program. 👩‍💻👨‍💻