### PR TITLE
Add dynamic interview prep roadmap based on interview date

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -180,6 +180,7 @@ class InterviewSessionTable(Base):
     roadmap: Mapped[list[dict[str, Any]]] = mapped_column(JSON)
     extracted_skills: Mapped[list[str]] = mapped_column(JSON, default=list)
     ml_match_score: Mapped[int] = mapped_column(Integer, default=0)
+    interview_date: Mapped[str | None] = mapped_column(String(32), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
 
@@ -396,6 +397,7 @@ class InterviewSession(BaseModel):
     userId: str
     jobTitle: str
     company: str
+    interviewDate: str | None = None
     jdText: str
     resumeText: str
     isEstimated: bool
@@ -413,6 +415,7 @@ class CreateInterviewSessionRequest(BaseModel):
     company: str
     jdText: str = Field(default="", max_length=15000)
     resumeText: str = Field(default="", max_length=8000)
+    interviewDate: str | None = None
 
     @field_validator("jobTitle", "company", mode="after")
     @classmethod
@@ -563,6 +566,7 @@ def session_from_table(session: InterviewSessionTable) -> InterviewSession:
         userId=session.user_id,
         jobTitle=session.job_title,
         company=session.company,
+        interviewDate=session.interview_date,
         jdText=session.jd_text,
         resumeText=session.resume_text,
         isEstimated=session.is_estimated,
@@ -616,6 +620,44 @@ def stable_number(seed: str, minimum: int, maximum: int) -> int:
     span = maximum - minimum + 1
     return minimum + (int(digest[:8], 16) % span)
 
+def calculate_days_remaining(
+    interview_date: str | None,
+) -> int | None:
+
+    if not interview_date:
+        return None
+
+    interview_dt = datetime.fromisoformat(interview_date).date()
+    today = utc_now().date()
+
+    if interview_dt < today:
+        raise HTTPException(
+            status_code=400,
+            detail="Interview date cannot be in the past"
+        )
+
+    return max(
+        1,
+        (interview_dt - today).days
+    )
+
+def get_roadmap_days(
+    days_remaining: int | None
+) -> int:
+
+    if days_remaining is None:
+        return 5
+
+    if days_remaining <= 2:
+        return 2
+
+    if days_remaining <= 5:
+        return 5
+
+    if days_remaining <= 14:
+        return min(days_remaining, 10)
+
+    return 10
 
 async def call_openrouter_json(
     system_prompt: str,
@@ -743,8 +785,12 @@ async def generate_session_payload(
     company: str,
     jd_text: str,
     resume_text: str,
+    days_remaining: int | None = None,
     client: httpx.AsyncClient | None = None,
 ) -> tuple[list[GapItem], int, list[QuestionItem], list[RoadmapDay], bool]:
+    target_days = get_roadmap_days(
+            days_remaining
+        )
     try:
         response = await call_openrouter_json(
             system_prompt=(
@@ -757,7 +803,7 @@ async def generate_session_payload(
                 '"roadmap":[{"day":1,"focusArea":"string","tasks":["string"]}]}. '
                 "gapAnalysis must be an array with 3 to 5 items. "
                 "questionBank must be an array with 6 to 10 items. "
-                "roadmap must be an array with exactly 5 days."
+                f"roadmap must be an array with exactly {target_days} days."
             ),
             user_prompt=(
                 f"Job title: {job_title}\n"
@@ -829,6 +875,10 @@ async def generate_session_payload(
             for item in raw_roadmap
             if isinstance(item, dict)
         ]
+        if len(roadmap) != target_days:
+            raise ValueError(
+                "Incorrect roadmap length"
+            )
 
         if len(roadmap) >= 1 and len(question_bank) >= 1 and len(gap_analysis) >= 1:
             return gap_analysis, readiness, question_bank, roadmap, False
@@ -886,53 +936,36 @@ async def generate_session_payload(
             tip="Demonstrate triage, communication, and follow-through.",
         ),
     ]
-    roadmap = [
-        RoadmapDay(
-            day=1,
-            focusArea="Company Research",
-            tasks=[
-                f"Research {company}'s products",
-                "Study the team and stack",
-                "Read recent company updates",
-            ],
-        ),
-        RoadmapDay(
-            day=2,
-            focusArea="Technical Review",
-            tasks=[
-                "Review core concepts",
-                f"Practice {job_title}-specific problems",
-                "Refresh system design patterns",
-            ],
-        ),
-        RoadmapDay(
-            day=3,
-            focusArea="Behavioral Prep",
-            tasks=[
-                "Prepare STAR stories",
-                "Practice behavioral questions",
-                "Review achievements with metrics",
-            ],
-        ),
-        RoadmapDay(
-            day=4,
-            focusArea="Mock Interviews",
-            tasks=[
-                "Run 2 mock rounds",
-                "Review weak answers",
-                "Refine delivery and examples",
-            ],
-        ),
-        RoadmapDay(
-            day=5,
-            focusArea="Final Review",
-            tasks=[
-                "Review notes",
-                "Prepare questions to ask",
-                "Rest before the interview",
-            ],
-        ),
+
+    focus_areas = [
+        "Company Research",
+        "Technical Review",
+        "Behavioral Prep",
+        "Mock Interviews",
+        "Final Review",
+        "Advanced Practice",
+        "System Design",
+        "Leadership Stories",
+        "Full Simulation",
+        "Interview Readiness",
     ]
+
+    roadmap = []
+
+    for day in range(1, target_days + 1):
+        roadmap.append(
+            RoadmapDay(
+                day=day,
+                focusArea=focus_areas[
+                    min(day - 1, len(focus_areas)-1)
+                ],
+                tasks=[
+                    f"Complete {focus_areas[min(day - 1, len(focus_areas)-1)]}",
+                    "Review weak areas",
+                    "Take notes"
+                ]
+            )
+        )
     is_estimated = not resume_text.strip() and not jd_text.strip()
     return gap_analysis, readiness, question_bank, roadmap, is_estimated
 
@@ -1298,6 +1331,16 @@ async def startup() -> None:
                 pass
 
             try:
+                conn.execute(
+                    text(
+                        "ALTER TABLE interview_sessions "
+                        "ADD COLUMN interview_date VARCHAR(32)"
+                    )
+                )
+            except Exception:
+                pass
+
+            try:
                 res = conn.execute(
                     text(
                         "SELECT COUNT(*) FROM mentor_chat_history WHERE session_id IS NULL"
@@ -1537,6 +1580,9 @@ async def create_session(
     db: Session = Depends(get_db),
 ) -> InterviewSession:
     client = getattr(request.app.state, "httpx_client", None)
+    days_remaining = calculate_days_remaining(
+        payload.interviewDate
+    )
     (
         gap_analysis,
         readiness,
@@ -1548,6 +1594,7 @@ async def create_session(
         payload.company,
         payload.jdText,
         payload.resumeText,
+        days_remaining=days_remaining,
         client=client,
     )
 
@@ -1560,6 +1607,7 @@ async def create_session(
         user_id=user_id,
         job_title=payload.jobTitle,
         company=payload.company,
+        interview_date=payload.interviewDate,
         jd_text=payload.jdText,
         resume_text=payload.resumeText,
         is_estimated=is_estimated,

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -63,6 +63,7 @@ export interface InterviewSession {
   mlMatchScore: number;
   isEstimated: boolean;
   createdAt: string;
+  interviewDate?: string;
 }
 
 export interface GapItem {
@@ -141,6 +142,7 @@ export interface CreateInterviewSessionInput {
   company: string;
   jdText: string;
   resumeText: string;
+  interviewDate?: string;
 }
 
 export interface CreateMockAttemptInput {

--- a/src/pages/InterviewPrepPage.tsx
+++ b/src/pages/InterviewPrepPage.tsx
@@ -48,6 +48,7 @@ export default function InterviewPrepPage({
   const [company, setCompany] = useState("");
   const [jd, setJd] = useState("");
   const [resume, setResume] = useState("");
+  const [interviewDate, setInterviewDate] = useState("");
   const [loading, setLoading] = useState(false);
   const [activeSession, setActiveSession] = useState<InterviewSession | null>(null);
   const [typeFilter, setTypeFilter] = useState<string>("all");
@@ -145,6 +146,7 @@ export default function InterviewPrepPage({
         company,
         jdText: jd,
         resumeText: resume,
+        interviewDate: interviewDate || undefined,
       });
       setActiveSession(session);
       setShowForm(false);
@@ -224,7 +226,7 @@ export default function InterviewPrepPage({
                 </select>
               </div>
             )}
-            <div className="grid md:grid-cols-2 gap-4">
+            <div className="grid md:grid-cols-3 gap-4">
               <div>
                 <Label>Job Title</Label>
                 <Input value={jobTitle} onChange={(e) => setJobTitle(e.target.value)} required className="mt-1 bg-secondary/50" placeholder="e.g. Senior Frontend Developer" />
@@ -232,6 +234,16 @@ export default function InterviewPrepPage({
               <div>
                 <Label>Company Name</Label>
                 <Input value={company} onChange={(e) => setCompany(e.target.value)} required className="mt-1 bg-secondary/50" placeholder="e.g. Google" />
+              </div>
+              <div>
+                <Label>Interview Date (Optional)</Label>
+                <Input
+                  type="date"
+                  value={interviewDate}
+                  min={new Date().toISOString().split("T")[0]}
+                  onChange={(e) => setInterviewDate(e.target.value)}
+                  className="mt-1 bg-secondary/50"
+                />
               </div>
             </div>
             <div>
@@ -567,7 +579,11 @@ export default function InterviewPrepPage({
               >
                 <div className="flex-1 cursor-pointer" onClick={() => setActiveSession(s)}>
                   <p className="font-medium text-foreground text-sm">{s.company} — {s.jobTitle}</p>
-                  <p className="text-xs text-muted-foreground">{new Date(s.createdAt).toLocaleDateString()}</p>
+                  {s.interviewDate && (
+                    <p className="text-xs text-primary">
+                      Interview: {new Date(s.interviewDate).toLocaleDateString()}
+                    </p>
+                  )}
                 </div>
                 <div className="flex items-center gap-2">
                   <Badge className={s.readinessScore >= 70 ? "bg-success/20 text-success" : "bg-warning/20 text-warning"}>


### PR DESCRIPTION
## Summary

### What problem does this PR solve?

Interview Prep roadmaps were always generated as a fixed 5-day plan, regardless of when the user's interview was scheduled.

### What changed?

* Added an optional Interview Date field to the Interview Prep form.
* Stored interview dates with interview sessions.
* Generated roadmap lengths dynamically based on days remaining until the interview.
* Added database migration support for the new interview date field.
* Kept existing sessions compatible.

Closes #179.

## Validation

* [x] `npm run build`
* [x] `npx tsc --noEmit`
* [x] `python -m compileall backend`

## Screenshots

When data is not selected - default 5 day plan

<img width="1704" height="971" alt="image" src="https://github.com/user-attachments/assets/985541aa-6a29-4689-b0cc-d4b226c5fa1a" />

Interview in 2 days

<img width="1706" height="976" alt="image" src="https://github.com/user-attachments/assets/c4bf0405-8413-42e6-bd93-8f7869048a64" />

Interview in 7 days

<img width="1709" height="978" alt="image" src="https://github.com/user-attachments/assets/3832d523-470f-4e23-8b98-cbbfab7b6ba6" />


## Risks

* Adds a new nullable `interview_date` database column.
* Existing sessions are unaffected.
