### PR TITLE
fix: align and improve job title dropdown

### DIFF
--- a/src/pages/JobTrackerPage.tsx
+++ b/src/pages/JobTrackerPage.tsx
@@ -765,18 +765,55 @@ export default function JobTrackerPage({ jobs, sessions, onAddJob, onUpdateJob, 
                   <div>
                     <Label>Job Title</Label>
 
-                    <Input
-                      list="job-roles"
-                      placeholder="e.g. Software Engineer"
-                      value={form.jobTitle}
-                      onChange={(e) => setForm({ ...form, jobTitle: e.target.value })}
-                      className="mt-1 bg-secondary/50"
-                    />
-                    <datalist id="job-roles">
-                      {JOB_ROLES.map((role) => (
-                        <option key={role} value={role} />
-                      ))}
-                    </datalist>
+                    <Popover open={jobRoleOpen} onOpenChange={setJobRoleOpen}>
+                      <PopoverTrigger asChild>
+                        <Button
+                          variant="outline"
+                          role="combobox"
+                          aria-expanded={jobRoleOpen}
+                          className="w-full mt-1 justify-between bg-secondary/50"
+                        >
+                          {form.jobTitle || "Select a job title"}
+                        </Button>
+                      </PopoverTrigger>
+
+                      <PopoverContent
+                        align="start"
+                        side="bottom"
+                        sideOffset={4}
+                        className="w-[var(--radix-popover-trigger-width)] p-0"
+                        onWheel={(e) => {
+                          e.stopPropagation();
+                        }}
+                      >
+                        <Command>
+                          <CommandInput placeholder="Search job title..." />
+
+                          <CommandEmpty>
+                            No job title found.
+                          </CommandEmpty>
+
+                          <CommandGroup className="max-h-64 overflow-y-auto">
+                            {JOB_ROLES.map((role) => (
+                              <CommandItem
+                                key={role}
+                                value={role}
+                                onSelect={() => {
+                                  setForm({
+                                    ...form,
+                                    jobTitle: role,
+                                  });
+
+                                  setJobRoleOpen(false);
+                                }}
+                              >
+                                {role}
+                              </CommandItem>
+                            ))}
+                          </CommandGroup>
+                        </Command>
+                      </PopoverContent>
+                    </Popover>
                   </div>
                   <div>
                     <Label>Job URL</Label>


### PR DESCRIPTION
## Summary

Closes #210 

- What problem does this PR solve?
- While adding a job we need to select the job title from the given dropdowns but that dropdown was not aligned properly both on Mobile and Desktop
- What changed?
- Fixed the job title dropdown to make it more responsive and make it more better and accessible

## Validation

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `python -m compileall backend`

## Screenshots

<img width="692" height="733" alt="image" src="https://github.com/user-attachments/assets/139012d4-e6f0-4f44-b687-221b74e7d702" />
<img width="1919" height="881" alt="image" src="https://github.com/user-attachments/assets/fe20f6d9-afaf-47b7-a20e-19454d171d41" />
<img width="274" height="581" alt="image" src="https://github.com/user-attachments/assets/1120aff7-7378-4be5-9279-c30dc428c09d" />


## Risks

NA

AI Usage: AI used to write commit messgae. 
