### PR TITLE
fix: proxy /api/* to Render backend to resolve Not Found error in men…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,10 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "rewrites": [
     {
+      "source": "/api/:path*",
+      "destination": "https://prepiq-backend-c79d.onrender.com/api/:path*"
+    },
+    {
       "source": "/(.*)",
       "destination": "/index.html"
     }


### PR DESCRIPTION
## Summary

 AI Mentor Chat returns "Not Found" error for all messages.
Added a rewrite rule in vercel.json to proxy /api/* requests to the Render backend. Previously, Vercel's SPA catch-all rewrite was intercepting all API calls and returning the React HTML page instead of forwarding them to the backend.

## Validation

- [ ] `npm run build`
- [ ] `npx tsc --noEmit`
- [ ] `python -m compileall backend`

## Screenshots

N/A — backend routing fix, no UI changes.

## Risks

None. Only vercel.json is changed. No migrations, no API changes, no database changes.
