### PR TITLE
fix: enforce payload size limits on LLM routes and Pydantic max_length

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -456,7 +456,7 @@ class CreateMockAttemptRequest(BaseModel):
     sessionId: str = ""
     question: str = Field(max_length=2000)
     userAnswer: str = Field(max_length=10000)
-    
+
 class PaginatedMockAttempts(BaseModel):
     items: list[MockAttempt]
     total: int

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -454,10 +454,9 @@ class MockAttempt(BaseModel):
 
 class CreateMockAttemptRequest(BaseModel):
     sessionId: str = ""
-    question: str
-    userAnswer: str
-
-
+    question: str = Field(max_length=2000)
+    userAnswer: str = Field(max_length=10000)
+    
 class PaginatedMockAttempts(BaseModel):
     items: list[MockAttempt]
     total: int
@@ -1246,14 +1245,13 @@ def require_current_user(
     return user
 
 
-def validate_payload_size(request: Request) -> None:
-    if "content-length" in request.headers:
-        length = int(request.headers["content-length"])
-        if length > 5242880:
-            raise HTTPException(
-                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-                detail="Request entity too large",
-            )
+async def validate_payload_size(request: Request) -> None:
+    body = await request.body()
+    if len(body) > 5242880:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="Request entity too large",
+        )
 
 
 app = FastAPI(title="PrepIQ Backend", version="2.0.0")
@@ -1651,6 +1649,7 @@ def get_mock_attempts(
     "/api/users/{user_id}/mocks",
     response_model=MockAttempt,
     status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(validate_payload_size)],
 )
 async def create_mock_attempt(
     user_id: str,
@@ -1833,6 +1832,7 @@ class GenerateQuestionResponse(BaseModel):
 @app.post(
     "/api/users/{user_id}/mock/generate-question",
     response_model=GenerateQuestionResponse,
+    dependencies=[Depends(validate_payload_size)],
 )
 async def generate_mock_question(
     user_id: str,
@@ -1999,7 +1999,7 @@ class MentorChatMessage(BaseModel):
 
 
 class MentorChatRequest(BaseModel):
-    message: str
+    message: str = Field(max_length=4000)
 
 
 @app.get(
@@ -2146,7 +2146,10 @@ def get_mentor_chat_messages(
     ]
 
 
-@app.post("/api/users/{user_id}/mentor-chat/sessions/{session_id}/messages")
+@app.post(
+    "/api/users/{user_id}/mentor-chat/sessions/{session_id}/messages",
+    dependencies=[Depends(validate_payload_size)],
+)
 async def post_mentor_chat_message(
     user_id: str,
     session_id: str,
@@ -2295,7 +2298,10 @@ class AnonymousChatRequest(BaseModel):
     messages: list[dict[str, str]]
 
 
-@app.post("/api/users/{user_id}/mentor-chat/anonymous")
+@app.post(
+    "/api/users/{user_id}/mentor-chat/anonymous",
+    dependencies=[Depends(validate_payload_size)],
+)
 async def post_anonymous_chat(
     user_id: str,
     payload: AnonymousChatRequest,


### PR DESCRIPTION
Fixes #220

## Summary
Fixes the payload size vulnerability reported in the issue.

## Changes Made
- `validate_payload_size` now reads actual request body bytes using `await request.body()` instead of trusting the spoofable `Content-Length` header
- Added `Depends(validate_payload_size)` to all 4 unprotected LLM routes:
  - `POST /api/users/{user_id}/mocks`
  - `POST /api/users/{user_id}/mock/generate-question`
  - `POST /api/users/{user_id}/mentor-chat/sessions/{session_id}/messages`
  - `POST /api/users/{user_id}/mentor-chat/anonymous`
- Added `max_length` validation to `CreateMockAttemptRequest`:
  - `question`: max 2000 chars
  - `userAnswer`: max 10000 chars
- Added `max_length` validation to `MentorChatRequest`:
  - `message`: max 4000 chars

## Testing
- 17/18 existing tests pass
- The 1 failure (`test_match_score_endpoint`) is a pre-existing issue due to missing `sklearn` — unrelated to this PR
- `test_ml_endpoints_payload_size_limit` passes ✅

---
*Contributing under GSSoC '26*