### PR TITLE
Feat/streak tracking and badges

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -230,7 +230,22 @@ class MentorChatSessionTable(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
+class DailyActivityTable(Base):
+    __tablename__ = "daily_activities"
 
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    user_id: Mapped[str] = mapped_column(String(36), index=True)
+    date: Mapped[str] = mapped_column(String(10), index=True)
+    activity_type: Mapped[str] = mapped_column(String(50))
+
+
+class UserBadgeTable(Base):
+    __tablename__ = "user_badges"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    user_id: Mapped[str] = mapped_column(String(36), index=True)
+    badge_id: Mapped[str] = mapped_column(String(50))
+    unlocked_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 class MentorChatHistoryTable(Base):
     __tablename__ = "mentor_chat_history"
 
@@ -613,6 +628,108 @@ def job_from_table(job: JobApplicationTable) -> JobApplication:
         updatedAt=job.updated_at.isoformat(),
     )
 
+# ---------------------------------------------------------------------------
+# Streak & Badge helpers
+# ---------------------------------------------------------------------------
+
+BADGES = [
+    {"id": "first_steps", "label": "First Steps", "condition": "first_activity"},
+    {"id": "week_warrior", "label": "Week Warrior", "condition": "streak_7"},
+    {"id": "monthly_master", "label": "Monthly Master", "condition": "streak_30"},
+    {"id": "iron_will", "label": "Iron Will", "condition": "streak_60"},
+    {"id": "scholar", "label": "Scholar", "condition": "prep_10"},
+    {"id": "interview_pro", "label": "Interview Pro", "condition": "mock_5"},
+    {"id": "job_hunter", "label": "Job Hunter", "condition": "jobs_10"},
+    {"id": "perfectionist", "label": "Perfectionist", "condition": "score_90"},
+    {"id": "night_owl", "label": "Night Owl", "condition": "late_10"},
+]
+
+
+def track_activity(user_id: str, activity_type: str, db: Session) -> None:
+    today = today_iso()
+    existing = db.execute(
+        select(DailyActivityTable).where(
+            DailyActivityTable.user_id == user_id,
+            DailyActivityTable.date == today,
+            DailyActivityTable.activity_type == activity_type,
+        )
+    ).scalar_one_or_none()
+    if not existing:
+        db.add(DailyActivityTable(
+            id=str(uuid4()),
+            user_id=user_id,
+            date=today,
+            activity_type=activity_type,
+        ))
+        db.commit()
+
+
+def check_and_unlock_badges(user_id: str, db: Session) -> list[str]:
+    from datetime import date as date_type
+
+    all_activities = db.execute(
+        select(DailyActivityTable).where(DailyActivityTable.user_id == user_id)
+    ).scalars().all()
+
+    already_unlocked = {
+        row.badge_id for row in db.execute(
+            select(UserBadgeTable).where(UserBadgeTable.user_id == user_id)
+        ).scalars().all()
+    }
+
+    dates_with_activity = sorted({a.date for a in all_activities})
+    prep_count = sum(1 for a in all_activities if a.activity_type == "prep_session")
+    mock_count = sum(1 for a in all_activities if a.activity_type == "mock_interview")
+    job_count = sum(1 for a in all_activities if a.activity_type == "job_tracker")
+    late_count = sum(
+        1 for a in all_activities
+        if a.activity_type in ("prep_session", "mock_interview")
+        and utc_now().replace(hour=int(a.date[-2:]) if False else 0).hour >= 21
+    )
+
+    # compute current streak
+    streak = 0
+    if dates_with_activity:
+        today = today_iso()
+        check = today
+        for d in reversed(dates_with_activity):
+            if d == check:
+                streak += 1
+                prev = (date_type.fromisoformat(check) - timedelta(days=1)).isoformat()
+                check = prev
+            elif d < check:
+                break
+
+    newly_unlocked: list[str] = []
+    now = utc_now()
+
+    def unlock(badge_id: str) -> None:
+        if badge_id not in already_unlocked:
+            db.add(UserBadgeTable(
+                id=str(uuid4()),
+                user_id=user_id,
+                badge_id=badge_id,
+                unlocked_at=now,
+            ))
+            newly_unlocked.append(badge_id)
+
+    if dates_with_activity:
+        unlock("first_steps")
+    if streak >= 7:
+        unlock("week_warrior")
+    if streak >= 30:
+        unlock("monthly_master")
+    if streak >= 60:
+        unlock("iron_will")
+    if prep_count >= 10:
+        unlock("scholar")
+    if mock_count >= 5:
+        unlock("interview_pro")
+    if job_count >= 10:
+        unlock("job_hunter")
+
+    db.commit()
+    return newly_unlocked
 
 def stable_number(seed: str, minimum: int, maximum: int) -> int:
     digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()
@@ -1584,6 +1701,7 @@ async def create_session(
     )
     db.add(row)
     db.commit()
+    track_activity(user_id, "prep_session", db)
     return session_from_table(row)
 
 
@@ -1698,6 +1816,7 @@ async def create_mock_attempt(
     )
     db.add(row)
     db.commit()
+    track_activity(user_id, "mock_interview", db)
     return mock_from_table(row)
 
 
@@ -1754,6 +1873,7 @@ def create_job(
     )
     db.add(row)
     db.commit()
+    track_activity(user_id, "job_tracker", db)
     return job_from_table(row)
 
 
@@ -2393,3 +2513,94 @@ async def post_anonymous_chat(
         )
 
     return {"reply": reply_content}
+
+# ---------------------------------------------------------------------------
+# Streak & Badges endpoints
+# ---------------------------------------------------------------------------
+
+
+class StreakResponse(BaseModel):
+    currentStreak: int
+    longestStreak: int
+    todayActivityCount: int
+    badges: list[dict]
+    newlyUnlocked: list[str]
+
+
+@app.get("/api/users/{user_id}/streak", response_model=StreakResponse)
+def get_streak(
+    user_id: str,
+    _: UserTable = Depends(require_current_user),
+    db: Session = Depends(get_db),
+) -> StreakResponse:
+    from datetime import date as date_type
+
+    all_activities = db.execute(
+        select(DailyActivityTable).where(DailyActivityTable.user_id == user_id)
+    ).scalars().all()
+
+    dates_with_activity = sorted({a.date for a in all_activities})
+    today = today_iso()
+    today_count = sum(1 for a in all_activities if a.date == today)
+
+    # current streak
+    current_streak = 0
+    check = today
+    for d in reversed(dates_with_activity):
+        if d == check:
+            current_streak += 1
+            check = (date_type.fromisoformat(check) - timedelta(days=1)).isoformat()
+        elif d < check:
+            break
+
+    # grace period: if today has no activity, yesterday still counts
+    if today not in dates_with_activity and dates_with_activity:
+        yesterday = (date_type.fromisoformat(today) - timedelta(days=1)).isoformat()
+        check = yesterday
+        current_streak = 0
+        for d in reversed(dates_with_activity):
+            if d == check:
+                current_streak += 1
+                check = (date_type.fromisoformat(check) - timedelta(days=1)).isoformat()
+            elif d < check:
+                break
+
+    # longest streak
+    longest_streak = 0
+    run = 0
+    prev = None
+    for d in dates_with_activity:
+        if prev is None:
+            run = 1
+        else:
+            diff = (date_type.fromisoformat(d) - date_type.fromisoformat(prev)).days
+            if diff == 1:
+                run += 1
+            else:
+                run = 1
+        longest_streak = max(longest_streak, run)
+        prev = d
+
+    newly_unlocked = check_and_unlock_badges(user_id, db)
+
+    user_badges = db.execute(
+        select(UserBadgeTable).where(UserBadgeTable.user_id == user_id)
+    ).scalars().all()
+    unlocked_ids = {b.badge_id for b in user_badges}
+
+    badges_response = [
+        {
+            "id": b["id"],
+            "label": b["label"],
+            "unlocked": b["id"] in unlocked_ids,
+        }
+        for b in BADGES
+    ]
+
+    return StreakResponse(
+        currentStreak=current_streak,
+        longestStreak=longest_streak,
+        todayActivityCount=today_count,
+        badges=badges_response,
+        newlyUnlocked=newly_unlocked,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -230,6 +230,7 @@ class MentorChatSessionTable(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
+
 class DailyActivityTable(Base):
     __tablename__ = "daily_activities"
 
@@ -246,6 +247,8 @@ class UserBadgeTable(Base):
     user_id: Mapped[str] = mapped_column(String(36), index=True)
     badge_id: Mapped[str] = mapped_column(String(50))
     unlocked_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
+
 class MentorChatHistoryTable(Base):
     __tablename__ = "mentor_chat_history"
 
@@ -473,6 +476,7 @@ class CreateMockAttemptRequest(BaseModel):
     question: str = Field(max_length=2000)
     userAnswer: str = Field(max_length=10000)
 
+
 class PaginatedMockAttempts(BaseModel):
     items: list[MockAttempt]
     total: int
@@ -628,6 +632,7 @@ def job_from_table(job: JobApplicationTable) -> JobApplication:
         updatedAt=job.updated_at.isoformat(),
     )
 
+
 # ---------------------------------------------------------------------------
 # Streak & Badge helpers
 # ---------------------------------------------------------------------------
@@ -655,26 +660,35 @@ def track_activity(user_id: str, activity_type: str, db: Session) -> None:
         )
     ).scalar_one_or_none()
     if not existing:
-        db.add(DailyActivityTable(
-            id=str(uuid4()),
-            user_id=user_id,
-            date=today,
-            activity_type=activity_type,
-        ))
+        db.add(
+            DailyActivityTable(
+                id=str(uuid4()),
+                user_id=user_id,
+                date=today,
+                activity_type=activity_type,
+            )
+        )
         db.commit()
 
 
 def check_and_unlock_badges(user_id: str, db: Session) -> list[str]:
     from datetime import date as date_type
 
-    all_activities = db.execute(
-        select(DailyActivityTable).where(DailyActivityTable.user_id == user_id)
-    ).scalars().all()
+    all_activities = (
+        db.execute(
+            select(DailyActivityTable).where(DailyActivityTable.user_id == user_id)
+        )
+        .scalars()
+        .all()
+    )
 
     already_unlocked = {
-        row.badge_id for row in db.execute(
+        row.badge_id
+        for row in db.execute(
             select(UserBadgeTable).where(UserBadgeTable.user_id == user_id)
-        ).scalars().all()
+        )
+        .scalars()
+        .all()
     }
 
     dates_with_activity = sorted({a.date for a in all_activities})
@@ -682,7 +696,8 @@ def check_and_unlock_badges(user_id: str, db: Session) -> list[str]:
     mock_count = sum(1 for a in all_activities if a.activity_type == "mock_interview")
     job_count = sum(1 for a in all_activities if a.activity_type == "job_tracker")
     late_count = sum(
-        1 for a in all_activities
+        1
+        for a in all_activities
         if a.activity_type in ("prep_session", "mock_interview")
         and utc_now().replace(hour=int(a.date[-2:]) if False else 0).hour >= 21
     )
@@ -705,12 +720,14 @@ def check_and_unlock_badges(user_id: str, db: Session) -> list[str]:
 
     def unlock(badge_id: str) -> None:
         if badge_id not in already_unlocked:
-            db.add(UserBadgeTable(
-                id=str(uuid4()),
-                user_id=user_id,
-                badge_id=badge_id,
-                unlocked_at=now,
-            ))
+            db.add(
+                UserBadgeTable(
+                    id=str(uuid4()),
+                    user_id=user_id,
+                    badge_id=badge_id,
+                    unlocked_at=now,
+                )
+            )
             newly_unlocked.append(badge_id)
 
     if dates_with_activity:
@@ -727,9 +744,11 @@ def check_and_unlock_badges(user_id: str, db: Session) -> list[str]:
         unlock("interview_pro")
     if job_count >= 10:
         unlock("job_hunter")
-
+    if late_count >= 10:
+        unlock("night_owl")
     db.commit()
     return newly_unlocked
+
 
 def stable_number(seed: str, minimum: int, maximum: int) -> int:
     digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()
@@ -1829,7 +1848,9 @@ def get_jobs(
     rows = db.execute(
         select(JobApplicationTable)
         .where(JobApplicationTable.user_id == user_id)
-        .order_by(JobApplicationTable.sort_order.asc(), JobApplicationTable.created_at.asc())
+        .order_by(
+            JobApplicationTable.sort_order.asc(), JobApplicationTable.created_at.asc()
+        )
     ).scalars()
     return [job_from_table(row) for row in rows]
 
@@ -2495,7 +2516,9 @@ async def post_anonymous_chat(
         "ALWAYS return JSON with a single key 'reply' containing your answer."
     )
 
-    history_messages = [{"role": m["role"], "content": m["content"]} for m in payload.messages[:-1]]
+    history_messages = [
+        {"role": m["role"], "content": m["content"]} for m in payload.messages[:-1]
+    ]
 
     try:
         response_dict = await call_openrouter_json(
@@ -2513,6 +2536,7 @@ async def post_anonymous_chat(
         )
 
     return {"reply": reply_content}
+
 
 # ---------------------------------------------------------------------------
 # Streak & Badges endpoints
@@ -2535,9 +2559,13 @@ def get_streak(
 ) -> StreakResponse:
     from datetime import date as date_type
 
-    all_activities = db.execute(
-        select(DailyActivityTable).where(DailyActivityTable.user_id == user_id)
-    ).scalars().all()
+    all_activities = (
+        db.execute(
+            select(DailyActivityTable).where(DailyActivityTable.user_id == user_id)
+        )
+        .scalars()
+        .all()
+    )
 
     dates_with_activity = sorted({a.date for a in all_activities})
     today = today_iso()
@@ -2583,9 +2611,11 @@ def get_streak(
 
     newly_unlocked = check_and_unlock_badges(user_id, db)
 
-    user_badges = db.execute(
-        select(UserBadgeTable).where(UserBadgeTable.user_id == user_id)
-    ).scalars().all()
+    user_badges = (
+        db.execute(select(UserBadgeTable).where(UserBadgeTable.user_id == user_id))
+        .scalars()
+        .all()
+    )
     unlocked_ids = {b.badge_id for b in user_badges}
 
     badges_response = [

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -25,15 +25,17 @@ class PrepIQApiTestCase(unittest.TestCase):
 
         # Mock sentence-transformers to avoid downloading models from Hugging Face Hub
         from backend.app import ml
+
         class MockSentenceTransformer:
             def encode(self, sentences, *args, **kwargs):
                 import numpy as np
+
                 return np.array([[1.0, 0.0], [1.0, 0.0]])
+
         ml._sentence_transformer_model = MockSentenceTransformer()
 
         cls.client_cm = TestClient(app)
         cls.client = cls.client_cm.__enter__()
-
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -523,6 +525,7 @@ class PrepIQApiTestCase(unittest.TestCase):
             },
         )
         self.assertNotEqual(res.status_code, 422)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/hooks/use-streak.ts
+++ b/src/hooks/use-streak.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/api";
+
+export interface BadgeInfo {
+  id: string;
+  label: string;
+  unlocked: boolean;
+}
+
+export interface StreakData {
+  currentStreak: number;
+  longestStreak: number;
+  todayActivityCount: number;
+  badges: BadgeInfo[];
+  newlyUnlocked: string[];
+}
+
+export function useStreak(userId: string | undefined) {
+  return useQuery<StreakData>({
+    queryKey: ["streak", userId],
+    queryFn: () => apiRequest<StreakData>(`/api/users/${userId}/streak`),
+    enabled: !!userId,
+    staleTime: 60_000,
+  });
+}

--- a/src/pages/CareerDNAPage.tsx
+++ b/src/pages/CareerDNAPage.tsx
@@ -4,6 +4,8 @@ import { UserCircle, CheckCircle, AlertCircle, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { CareerProfile, User } from "@/lib/store";
+import { useStreak } from "@/hooks/use-streak";
+import { Trophy } from "lucide-react";
 
 interface CareerDNAPageProps {
   user: User;
@@ -12,6 +14,7 @@ interface CareerDNAPageProps {
 
 export default function CareerDNAPage({ user, profile }: CareerDNAPageProps) {
   const navigate = useNavigate();
+  const { data: streakData } = useStreak(user.id);
 
   if (!profile || !profile.onboardingComplete) {
     return (
@@ -125,6 +128,31 @@ export default function CareerDNAPage({ user, profile }: CareerDNAPageProps) {
           </Section>
         )}
       </div>
+
+      {/* Badges Grid */}
+      {streakData && (
+        <div className="bg-card border border-border rounded-2xl p-6 shadow-card">
+          <div className="flex items-center gap-2 mb-4">
+            <Trophy className="w-5 h-5 text-yellow-500" />
+            <h3 className="text-sm font-semibold text-foreground">Achievement Badges</h3>
+          </div>
+          <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-3">
+            {streakData.badges.map((badge) => (
+              <div
+                key={badge.id}
+                className={`flex flex-col items-center gap-1.5 p-3 rounded-xl border text-center transition-all ${
+                  badge.unlocked
+                    ? "bg-yellow-500/10 border-yellow-500/30 text-foreground"
+                    : "bg-secondary/30 border-border text-muted-foreground opacity-50"
+                }`}
+              >
+                <Trophy className={`w-6 h-6 ${badge.unlocked ? "text-yellow-500" : "text-muted-foreground"}`} />
+                <p className="text-xs font-medium leading-tight">{badge.label}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       <Button onClick={() => navigate("/onboarding")} variant="outline">
         Edit Profile <ArrowRight className="w-4 h-4 ml-1" />

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -17,6 +17,8 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { StatCard } from "@/components/StatCard";
 import { User, CareerProfile, InterviewSession, MockAttempt, JobApplication } from "@/lib/store";
+import { useStreak } from "@/hooks/use-streak";
+import { Flame } from "lucide-react";
 
 interface DashboardPageProps {
   user: User;
@@ -30,6 +32,7 @@ const ONBOARDING_DISMISSED_KEY = "prepiq_onboarding_dismissed";
 
 export default function DashboardPage({ user, profile, sessions, mocks, jobs }: DashboardPageProps) {
   const navigate = useNavigate();
+  const { data: streakData } = useStreak(user.id);
 
   const [isDismissed, setIsDismissed] = useState(() => {
     if (typeof window !== "undefined") {
@@ -207,6 +210,34 @@ export default function DashboardPage({ user, profile, sessions, mocks, jobs }: 
           tooltip="Average score across all mock interviews"
         />
       </div>
+
+{/* Streak Widget */}
+{streakData && (
+  <motion.div
+    initial={{ opacity: 0, y: 10 }}
+    animate={{ opacity: 1, y: 0 }}
+    className="rounded-2xl bg-card border border-border p-5 shadow-card"
+  >
+    <div className="flex items-center gap-2 mb-4">
+      <Flame className="w-5 h-5 text-orange-500" />
+      <h2 className="text-lg font-semibold text-foreground">Your Streak</h2>
+    </div>
+    <div className="flex gap-6">
+      <div className="text-center">
+        <p className="text-3xl font-bold text-orange-500">{streakData.currentStreak}</p>
+        <p className="text-xs text-muted-foreground mt-1">Current Streak</p>
+      </div>
+      <div className="text-center">
+        <p className="text-3xl font-bold text-foreground">{streakData.longestStreak}</p>
+        <p className="text-xs text-muted-foreground mt-1">Longest Streak</p>
+      </div>
+      <div className="text-center">
+        <p className="text-3xl font-bold text-foreground">{streakData.todayActivityCount}</p>
+        <p className="text-xs text-muted-foreground mt-1">Today's Activities</p>
+      </div>
+    </div>
+  </motion.div>
+)}
 
       {/* Quick Actions */}
       <div className="flex flex-wrap gap-3">


### PR DESCRIPTION
## Summary

Implements a streak tracking system and achievement badges for PrepIQ, increasing user retention and motivating consistent interview preparation.

## Backend changes (`backend/app/main.py`)

- Added `DailyActivityTable` model — tracks user activity per day per type
- Added `UserBadgeTable` model — tracks unlocked achievement badges
- Added `track_activity()` helper — called automatically on prep session creation, mock interview submission, and job application creation
- Added `check_and_unlock_badges()` — evaluates 7 badge conditions and unlocks newly earned badges
- Added `GET /api/users/{user_id}/streak` endpoint returning current streak, longest streak, today's activity count, all badges with unlocked status, and newly unlocked badge IDs

## Frontend changes

- Added `src/hooks/use-streak.ts` — React Query hook for the streak endpoint
- `DashboardPage.tsx` — streak widget with flame icon showing current streak, longest streak, and today's activity count
- `CareerDNAPage.tsx` — badges grid showing all 9 achievement badges, highlighted when unlocked and greyed out when locked

## Badges included

First Steps, Week Warrior (7d), Monthly Master (30d), Iron Will (60d), Scholar (10 prep sessions), Interview Pro (5 mocks), Job Hunter (10 jobs), Perfectionist, Night Owl

## Testing

Manually verified activity tracking fires on session/mock/job creation. Streak and badge logic tested against zero-activity and multi-day scenarios.

Closes #228