### PR TITLE
fix: handle 401 auth expiration without full page reload

### DIFF
--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { apiRequest } from "@/lib/api";
+import { apiRequest, AUTH_EXPIRED_EVENT } from "@/lib/api";
 import { getMockAttemptItems, type MockAttempt, type PaginatedMockAttempts } from "@/lib/store";
 
 describe("apiRequest", () => {
@@ -52,6 +52,32 @@ describe("apiRequest", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(apiRequest("/api/auth/login", { method: "POST" })).rejects.toThrow("Invalid credentials");
+  });
+
+  it("dispatches an auth expired event for protected 401 responses", async () => {
+    localStorage.setItem(
+      "prepiq_session",
+      JSON.stringify({
+        user: { id: "user-1", name: "Test User", email: "test@example.com" },
+        token: "sample-token",
+      }),
+    );
+
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ detail: "Session expired" }), {
+        status: 401,
+        statusText: "Unauthorized",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(apiRequest("/api/users/me")).rejects.toThrow("Session expired");
+    expect(localStorage.getItem("prepiq_session")).toBeNull();
+    expect(dispatchSpy).toHaveBeenCalled();
+    expect(dispatchSpy.mock.calls[0][0]).toMatchObject({ type: AUTH_EXPIRED_EVENT });
   });
 });
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,6 @@
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
 export const SESSION_KEY = "prepiq_session";
+export const AUTH_EXPIRED_EVENT = "prepiq:auth-expired";
 
 interface SessionPayload {
   user: {
@@ -53,7 +54,9 @@ export async function apiRequest<T>(path: string, init?: RequestInit): Promise<T
   if (!response.ok) {
     if (response.status === 401 && !path.includes("/api/auth/")) {
       localStorage.removeItem(SESSION_KEY);
-      window.location.href = "/login";
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new CustomEvent(AUTH_EXPIRED_EVENT));
+      }
     }
     throw new Error(await parseError(response));
   }

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import { apiRequest, SESSION_KEY } from "@/lib/api";
+import { apiRequest, AUTH_EXPIRED_EVENT, SESSION_KEY } from "@/lib/api";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 
@@ -191,6 +191,13 @@ export function useAuth() {
       return;
     }
 
+    const handleAuthExpired = () => {
+      setSessionState(null);
+      setSession(null);
+    };
+
+    window.addEventListener(AUTH_EXPIRED_EVENT, handleAuthExpired);
+
     apiRequest<User>("/api/auth/me")
       .then((user) => {
         if (!active) return;
@@ -209,6 +216,7 @@ export function useAuth() {
 
     return () => {
       active = false;
+      window.removeEventListener(AUTH_EXPIRED_EVENT, handleAuthExpired);
     };
   }, []);
 


### PR DESCRIPTION
Closes #231

## Summary

This PR replaces browser-level navigation on protected `401 Unauthorized` responses with an SPA-safe authentication expiration flow.

Previously, when a protected API request returned `401`, the application cleared the session and redirected using:

```ts
window.location.href = "/login";
```

This bypassed React Router and caused a full page reload.

With this change, authentication expiration is handled through centralized auth state management, allowing React Router to navigate users back to the login page without reloading the application.

---

## Root Cause

Protected `401 Unauthorized` responses were handled directly inside `apiRequest()` using:

```ts
localStorage.removeItem(SESSION_KEY);
window.location.href = "/login";
```

Because `window.location.href` performs a document-level navigation, the browser reloaded the application and fetched assets again instead of using the existing SPA routing flow.

---

## Changes Made

### 1. Added auth expiration event

Introduced a shared event constant:

```ts
export const AUTH_EXPIRED_EVENT = "prepiq:auth-expired";
```

### 2. Updated protected 401 handling

**Before**

```ts
localStorage.removeItem(SESSION_KEY);
window.location.href = "/login";
```

**After**

```ts
localStorage.removeItem(SESSION_KEY);
window.dispatchEvent(new CustomEvent(AUTH_EXPIRED_EVENT));
```

This preserves the existing session cleanup while avoiding browser-level navigation.

### 3. Connected auth state to expiration events

Added an event listener in `useAuth()` that:

* Clears in-memory authentication state
* Clears persisted session state
* Allows existing React Router auth flow to navigate users appropriately

### 4. Added regression tests

Added test coverage verifying that protected `401` responses:

* Remove the stored session
* Dispatch the auth expiration event
* Continue throwing the appropriate authentication error

---

## Verification

### Protected 401 Flow

1. Logged into the application.
2. Modified the stored authentication token to make it invalid.
3. Triggered a protected API request.
4. Observed a `401 Unauthorized` response.

Result: ✅ Passed

### Session Cleanup

Confirmed `prepiq_session` is removed after a protected `401`.

Result: ✅ Passed

### SPA Navigation

Confirmed navigation returns the user to the login page through application state updates.

Result: ✅ Passed

### No Full Page Reload

Verified that after the `401`:

* No document-level navigation occurs
* React bundles are not downloaded again
* Application remains within the SPA lifecycle

Result: ✅ Passed

### Regression Tests

Verified test coverage for:

* Session removal
* Auth expiration event dispatching

Result: ✅ Passed

---

## Impact

### Before

* Protected `401` responses triggered `window.location.href`
* Browser performed a full page reload
* React application was reinitialized
* Static assets were fetched again

### After

* Protected `401` responses dispatch an auth expiration event
* Auth state is cleared centrally
* React Router handles navigation
* No full browser reload occurs

---

## Files Modified

* `src/lib/api.ts`
* `src/lib/store.ts`
* `src/lib/api.test.ts`

---

## Risks

Low risk.

The change only affects handling of protected `401 Unauthorized` responses. Authentication validation, session storage format, and API behavior remain unchanged.
