### PR TITLE
fix: make command palette search responsive to sidebar collapse

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -79,23 +79,33 @@ export function AppSidebar({ onLogout }: AppSidebarProps) {
 
       <SidebarContent>
         <div className="px-2 py-2 hidden md:block">
-          <button
-            onClick={() => {
-              window.dispatchEvent(
-                new KeyboardEvent("keydown", {
-                  key: "k",
-                  ctrlKey: true,
-                })
-              );
-            }}
-            className="w-full flex items-center justify-between rounded-xl border border-border/60 bg-background/40 px-4 py-3 text-sm text-muted-foreground transition-all duration-200 hover:bg-white/5 hover:border-white/10 hover:text-foreground"
-          >
-            <span>Search pages...</span>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                tooltip="Search"
+                onClick={() => {
+                  window.dispatchEvent(
+                    new KeyboardEvent("keydown", {
+                      key: "k",
+                      ctrlKey: true,
+                    })
+                  );
+                }}
+              >
+                <BookOpen className="h-4 w-4 shrink-0" />
 
-            <kbd className="rounded border border-border bg-muted px-2 py-0.5 text-xs">
-              Ctrl K
-            </kbd>
-          </button>
+                {!collapsed && (
+                  <>
+                    <span>Search pages...</span>
+
+                    <kbd className="ml-auto rounded border border-border bg-muted px-2 py-0.5 text-xs">
+                      Ctrl K
+                    </kbd>
+                  </>
+                )}
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
         </div>
         <SidebarGroup>
           <SidebarGroupContent>


### PR DESCRIPTION
## Summary

Closes #202 

- What problem does this PR solve?
- The command palette was not shrink like thhe other buttons in the sidebar when the sidebar is collapsed to show just the icon instead of whole button with label.
- What changed?
- The command palette now shrinks into just icon button when the sidebar is collapsed like the other buttons. 

## Validation

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `python -m compileall backend`

## Screenshots


https://github.com/user-attachments/assets/5479796e-7a88-4f9d-a662-32b5f1d0bb78


## Risks

NA