### PR TITLE
fix: add pagination to jobs and sessions endpoints (#214)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -468,11 +468,28 @@ class CreateMockAttemptRequest(BaseModel):
     question: str = Field(max_length=2000)
     userAnswer: str = Field(max_length=10000)
 
+
 class PaginatedMockAttempts(BaseModel):
     items: list[MockAttempt]
     total: int
     limit: int
     offset: int
+
+
+class PaginatedInterviewSessions(BaseModel):
+    items: list[InterviewSession]
+    total: int
+    page: int
+    limit: int
+    total_pages: int
+
+
+class PaginatedJobApplications(BaseModel):
+    items: list[JobApplication]
+    total: int
+    page: int
+    limit: int
+    total_pages: int
 
 
 JobStatus = Literal["Applied", "Screening", "Interview", "Offer", "Rejected", "Ghosted"]
@@ -982,59 +999,12 @@ async def generate_session_payload(
 
 def _significant_tokens(text: str) -> set[str]:
     stopwords = {
-        "the",
-        "and",
-        "a",
-        "an",
-        "of",
-        "to",
-        "is",
-        "are",
-        "in",
-        "for",
-        "on",
-        "with",
-        "that",
-        "this",
-        "it",
-        "as",
-        "at",
-        "by",
-        "from",
-        "be",
-        "or",
-        "not",
-        "have",
-        "has",
-        "was",
-        "were",
-        "will",
-        "can",
-        "i",
-        "you",
-        "your",
-        "we",
-        "our",
-        "they",
-        "their",
-        "what",
-        "which",
-        "when",
-        "where",
-        "why",
-        "how",
-        "do",
-        "does",
-        "did",
-        "so",
-        "but",
-        "if",
-        "then",
-        "because",
-        "there",
-        "these",
-        "those",
-        "meaning",
+        "the", "and", "a", "an", "of", "to", "is", "are", "in", "for", "on",
+        "with", "that", "this", "it", "as", "at", "by", "from", "be", "or",
+        "not", "have", "has", "was", "were", "will", "can", "i", "you", "your",
+        "we", "our", "they", "their", "what", "which", "when", "where", "why",
+        "how", "do", "does", "did", "so", "but", "if", "then", "because",
+        "there", "these", "those", "meaning",
     }
     return {
         token.lower()
@@ -1044,33 +1014,11 @@ def _significant_tokens(text: str) -> set[str]:
 
 
 FALLBACK_TECHNICAL_TERMS = {
-    "model",
-    "data",
-    "training",
-    "test",
-    "accuracy",
-    "performance",
-    "generalize",
-    "generalization",
-    "variance",
-    "bias",
-    "overfit",
-    "overfitting",
-    "unseen",
-    "feature",
-    "dataset",
-    "classification",
-    "regression",
-    "optimization",
-    "neural",
-    "network",
-    "algorithm",
-    "prediction",
-    "validation",
-    "loss",
-    "error",
-    "regularization",
-    "parameter",
+    "model", "data", "training", "test", "accuracy", "performance", "generalize",
+    "generalization", "variance", "bias", "overfit", "overfitting", "unseen",
+    "feature", "dataset", "classification", "regression", "optimization", "neural",
+    "network", "algorithm", "prediction", "validation", "loss", "error",
+    "regularization", "parameter",
 }
 
 
@@ -1542,18 +1490,33 @@ def save_profile(
     return profile
 
 
-@app.get("/api/users/{user_id}/sessions", response_model=list[InterviewSession])
+@app.get("/api/users/{user_id}/sessions", response_model=PaginatedInterviewSessions)
 def get_sessions(
     user_id: str,
+    page: int = Query(default=1, ge=1, description="Page number (1-based)"),
+    limit: int = Query(default=20, ge=1, le=100, description="Results per page (1-100)"),
     _: UserTable = Depends(require_current_user),
     db: Session = Depends(get_db),
-) -> list[InterviewSession]:
+) -> PaginatedInterviewSessions:
+    offset = (page - 1) * limit
+    total = db.execute(
+        select(func.count()).select_from(InterviewSessionTable)
+        .where(InterviewSessionTable.user_id == user_id)
+    ).scalar_one()
     rows = db.execute(
         select(InterviewSessionTable)
         .where(InterviewSessionTable.user_id == user_id)
         .order_by(InterviewSessionTable.created_at.asc())
-    ).scalars()
-    return [session_from_table(row) for row in rows]
+        .limit(limit)
+        .offset(offset)
+    ).scalars().all()
+    return PaginatedInterviewSessions(
+        items=[session_from_table(row) for row in rows],
+        total=total,
+        page=page,
+        limit=limit,
+        total_pages=(total + limit - 1) // limit,
+    )
 
 
 @app.get("/api/users/{user_id}/sessions/{session_id}", response_model=InterviewSession)
@@ -1748,18 +1711,33 @@ async def create_mock_attempt(
     return mock_from_table(row)
 
 
-@app.get("/api/users/{user_id}/jobs", response_model=list[JobApplication])
+@app.get("/api/users/{user_id}/jobs", response_model=PaginatedJobApplications)
 def get_jobs(
     user_id: str,
+    page: int = Query(default=1, ge=1, description="Page number (1-based)"),
+    limit: int = Query(default=20, ge=1, le=100, description="Results per page (1-100)"),
     _: UserTable = Depends(require_current_user),
     db: Session = Depends(get_db),
-) -> list[JobApplication]:
+) -> PaginatedJobApplications:
+    offset = (page - 1) * limit
+    total = db.execute(
+        select(func.count()).select_from(JobApplicationTable)
+        .where(JobApplicationTable.user_id == user_id)
+    ).scalar_one()
     rows = db.execute(
         select(JobApplicationTable)
         .where(JobApplicationTable.user_id == user_id)
         .order_by(JobApplicationTable.sort_order.asc(), JobApplicationTable.created_at.asc())
-    ).scalars()
-    return [job_from_table(row) for row in rows]
+        .limit(limit)
+        .offset(offset)
+    ).scalars().all()
+    return PaginatedJobApplications(
+        items=[job_from_table(row) for row in rows],
+        total=total,
+        page=page,
+        limit=limit,
+        total_pages=(total + limit - 1) // limit,
+    )
 
 
 @app.post(

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -379,7 +379,12 @@ class PrepIQApiTestCase(unittest.TestCase):
 
         jobs = self.client.get(f"/api/users/{user_id}/jobs", headers=headers)
         self.assertEqual(jobs.status_code, 200, jobs.text)
-        self.assertEqual(jobs.json(), [])
+        jobs_payload = jobs.json()
+        self.assertEqual(jobs_payload["items"], [])
+        self.assertEqual(jobs_payload["total"], 0)
+        self.assertEqual(jobs_payload["page"], 1)
+        self.assertEqual(jobs_payload["limit"], 20)
+        self.assertEqual(jobs_payload["total_pages"], 0)
 
         delete_session = self.client.delete(
             f"/api/users/{user_id}/sessions/{session_payload['id']}",
@@ -389,7 +394,12 @@ class PrepIQApiTestCase(unittest.TestCase):
 
         sessions = self.client.get(f"/api/users/{user_id}/sessions", headers=headers)
         self.assertEqual(sessions.status_code, 200, sessions.text)
-        self.assertEqual(sessions.json(), [])
+        sessions_payload = sessions.json()
+        self.assertEqual(sessions_payload["items"], [])
+        self.assertEqual(sessions_payload["total"], 0)
+        self.assertEqual(sessions_payload["page"], 1)
+        self.assertEqual(sessions_payload["limit"], 20)
+        self.assertEqual(sessions_payload["total_pages"], 0)
 
         mocks_after_delete = self.client.get(
             f"/api/users/{user_id}/mocks", headers=headers

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -138,6 +138,22 @@ export interface JobApplication {
   updatedAt: string;
 }
 
+export interface PaginatedJobApplications {
+  items: JobApplication[];
+  total: number;
+  page: number;
+  limit: number;
+  total_pages: number;
+}
+
+export interface PaginatedInterviewSessions {
+  items: InterviewSession[];
+  total: number;
+  page: number;
+  limit: number;
+  total_pages: number;
+}
+
 export interface CreateInterviewSessionInput {
   jobTitle: string;
   company: string;
@@ -179,6 +195,14 @@ function setSession(session: AuthSession | null) {
 // Legacy useProtectedResource hook removed in favor of TanStack React Query.
 
 export function getMockAttemptItems(payload: MockAttempt[] | PaginatedMockAttempts): MockAttempt[] {
+  return Array.isArray(payload) ? payload : payload.items;
+}
+
+export function getJobApplicationItems(payload: JobApplication[] | PaginatedJobApplications): JobApplication[] {
+  return Array.isArray(payload) ? payload : payload.items;
+}
+
+export function getInterviewSessionItems(payload: InterviewSession[] | PaginatedInterviewSessions): InterviewSession[] {
   return Array.isArray(payload) ? payload : payload.items;
 }
 
@@ -303,7 +327,10 @@ export function useInterviewSessions(userId: string | undefined) {
   const queryClient = useQueryClient();
   const sessionsQuery = useQuery<InterviewSession[]>({
     queryKey: ["interviewSessions", userId],
-    queryFn: () => apiRequest<InterviewSession[]>(`/api/users/${userId}/sessions`),
+    queryFn: async () => {
+      const payload = await apiRequest<InterviewSession[] | PaginatedInterviewSessions>(`/api/users/${userId}/sessions`);
+      return getInterviewSessionItems(payload);
+    },
     enabled: !!userId,
   });
 
@@ -389,7 +416,10 @@ export function useJobApplications(userId: string | undefined) {
   const queryClient = useQueryClient();
   const jobsQuery = useQuery<JobApplication[]>({
     queryKey: ["jobApplications", userId],
-    queryFn: () => apiRequest<JobApplication[]>(`/api/users/${userId}/jobs`),
+    queryFn: async () => {
+      const payload = await apiRequest<JobApplication[] | PaginatedJobApplications>(`/api/users/${userId}/jobs`);
+      return getJobApplicationItems(payload);
+    },
     enabled: !!userId,
   });
 
@@ -446,4 +476,3 @@ export function useJobApplications(userId: string | undefined) {
   const jobs = jobsQuery.data ?? [];
   return { jobs, addJob, updateJob, deleteJob, jobsError: jobsQuery.error instanceof Error ? jobsQuery.error.message : null, jobsLoading: jobsQuery.isLoading };
 }
-


### PR DESCRIPTION
Fixes #214

Problem
The `GET /api/users/{user_id}/jobs` and `GET /api/users/{user_id}/sessions` endpoints returned the entire dataset in a single response with no pagination support. As records grew, this caused slow API responses, large payloads, and higher database load.

 Changes Made

New Pydantic models:
- `PaginatedJobApplications` — paginated response wrapper for job applications
- `PaginatedInterviewSessions` — paginated response wrapper for interview sessions

Updated endpoints:
- `GET /api/users/{user_id}/jobs` — now accepts `page` (default: 1) and `limit` (default: 20, max: 100) query parameters
- `GET /api/users/{user_id}/sessions` — now accepts `page` (default: 1) and `limit` (default: 20, max: 100) query parameters

Both endpoints now return:
json
{
  "items": [...],
  "total": 50,
  "page": 1,
  "limit": 20,
  "total_pages": 3
}
```

Testing Done
- `GET /api/users/{user_id}/jobs?page=1&limit=20` returns first 20 jobs with correct metadata
- `GET /api/users/{user_id}/sessions?page=2&limit=10` returns correct slice
- Defaults work correctly without any query params
- Existing create, update, and delete endpoints unaffected
