### PR TITLE
fix: enforce validation for all added work history entries

### DIFF
--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -246,13 +246,29 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
         const currentYear = new Date().getFullYear();
 
         for (const entry of workHistory) {
-          const isFilled = entry.jobTitle.trim() || entry.company.trim() || entry.from.trim() || entry.to.trim();
+          const isFilled =
+            entry.jobTitle.trim() ||
+            entry.company.trim() ||
+            entry.from.trim() ||
+            entry.to.trim();
+
+          // If there are multiple entries, none can remain empty
+          if (!isFilled && workHistory.length > 1) {
+            return "Please fill all added work experiences or remove the empty ones.";
+          }
+
+          // Allow the single default empty card
           if (!isFilled) continue;
 
           filledCount++;
 
-          if (!entry.jobTitle.trim() || !entry.company.trim()) {
-            return "Please provide both job title and company for all work entries.";
+          if (
+            !entry.jobTitle.trim() ||
+            !entry.company.trim() ||
+            !entry.from.trim() ||
+            !entry.to.trim()
+          ) {
+            return "Please complete job title, company, start year, and end year for all work entries.";
           }
 
           if (entry.from.trim()) {
@@ -278,7 +294,7 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
         }
 
         if (filledCount === 0) {
-          return "Add at least one work entry with job title and company.";
+          return "Add at least one complete work entry including job title, company, start year, and end year.";
         }
 
         return null;


### PR DESCRIPTION
## Summary

Closes #241 

- What problem does this PR solve?
- Fixes validation issues in step 3 of the work onboarding in career dna 
- What changed?
- ensured that any work exp added by clicking add exp. should be completely filled or deleted before moving forward. 

## Validation

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `python -m compileall backend`

## Screenshots

<img width="977" height="857" alt="image" src="https://github.com/user-attachments/assets/3d12f5b2-7ebd-49b6-b7d0-40477cdd9b0c" />
<img width="987" height="821" alt="image" src="https://github.com/user-attachments/assets/c488a057-c2b0-4e23-a761-56709459270e" />
<img width="937" height="882" alt="image" src="https://github.com/user-attachments/assets/7ee372c6-5593-4d9d-984c-0079f9091076" />


## Risks

NA