### PR TITLE
docs: add missing required CORS_ORIGINS variable to local setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ For simple manual local development, use SQLite instead of the Docker-oriented P
 ```env
 DATABASE_URL=sqlite:///./backend/local.db
 APP_SECRET=any-long-random-string-only-for-local-dev
+CORS_ORIGINS=http://localhost:8080,http://127.0.0.1:8080
 ```
 
 > ⚠️ Never commit a real `APP_SECRET`.


### PR DESCRIPTION
## Summary
- **What problem does this PR solve?** This PR resolves a critical startup crash in the local backend environment caused by a missing required configuration value in the example documentation.
- **What changed?** Added the `CORS_ORIGINS` environment variable (mapped to `http://localhost:8080` and `http://127.0.0.1:8080`) to the example `.env` block within the `2. Environment setup` section of the `README.md`.

## Validation
- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `python -m compileall backend`
- [x] Verified local backend startup (`uvicorn`) succeeds with the updated configuration.

## Screenshots
N/A (Documentation update only)

## Risks
- **Migration/Deployment:** None. This change solely affects local developer setup instructions and has no impact on production configurations.
- **API Concerns:** None.