### PR TITLE
fix: add auth protection to `/api/debug-db` endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1643,7 +1643,10 @@ async def contact(payload: ContactRequest):
 
 
 @app.get("/api/debug-db")
-def debug_db(db: Session = Depends(get_db)):
+def debug_db(
+    db: Session = Depends(get_db),
+    user: UserTable = Depends(require_current_user),
+):
     try:
         from sqlalchemy import inspect
         inspector = inspect(engine)


### PR DESCRIPTION
## Summary

The `/api/debug-db` debugging endpoint exposes the complete database schema (all table names and column names) without any authentication.

## Changes

- **backend/app/main.py**: Added `user: UserTable = Depends(require_current_user)` to the `debug_db` handler

Before:
```python
@app.get("/api/debug-db")
def debug_db(db: Session = Depends(get_db)):
```

After:
```python
@app.get("/api/debug-db")
def debug_db(
    db: Session = Depends(get_db),
    user: UserTable = Depends(require_current_user),
):
```

## Validation

- [ ] `python -m compileall backend`
- [ ] `python -m unittest discover -s backend/tests -p "test_*.py"`

Fixes #280