### PR TITLE
fix: handle empty/null sessionId for custom mock interview questions

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -499,7 +499,7 @@ class MockAttempt(BaseModel):
 
 
 class CreateMockAttemptRequest(BaseModel):
-    sessionId: str = ""
+    sessionId: str | None = None
     question: str = Field(max_length=2000)
     userAnswer: str = Field(max_length=10000)
 
@@ -2024,7 +2024,7 @@ async def create_mock_attempt(
     )
     row = MockAttemptTable(
         id=str(uuid4()),
-        session_id=payload.sessionId,
+        session_id=payload.sessionId or "",
         user_id=user_id,
         question=payload.question,
         user_answer=payload.userAnswer,

--- a/src/pages/MockInterviewPage.tsx
+++ b/src/pages/MockInterviewPage.tsx
@@ -275,7 +275,7 @@ export default function MockInterviewPage({
     setIsTimerRunning(false);
     try {
       const attempt = await onAddAttempt({
-        sessionId: selectedSession !== "custom" ? selectedSession : "",
+        sessionId: selectedSession !== "custom" ? selectedSession : null,
         question,
         userAnswer: latestAnswerRef.current,
       });


### PR DESCRIPTION
## Summary

Custom mock questions silently fail because `sessionId` is sent as an empty string, which doesn't get stored or handled correctly.

## Changes

### Frontend (`src/pages/MockInterviewPage.tsx`)
- Send `null` instead of `""` when `selectedSession === "custom"`

### Backend (`backend/app/main.py`)
- Changed `CreateMockAttemptRequest.sessionId` from `str = ""` to `str | None = None`
- Convert `None` to `""` before storing in DB to maintain backward compatibility

## Validation

- [ ] `npm run build`
- [ ] `npx tsc --noEmit`
- [ ] `python -m compileall backend`
- [ ] `python -m unittest discover -s backend/tests -p "test_*.py"`

Fixes #281