### PR TITLE
fix: add missing validateSkills helper for onboarding

### DIFF
--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -279,6 +279,19 @@ export default function OnboardingPage({ user, profile, onSave }: OnboardingPage
     }
     return "";
   };
+  const validateSkills = (): string => {
+  const technicalError = validateTechnicalSkills();
+  if (technicalError) {
+    return technicalError;
+  }
+
+  const softSkillError = validateSoftSkills();
+  if (softSkillError) {
+    return softSkillError;
+  }
+
+  return "";
+};
 
   const validateStep = (currentStep: number): string | null => {
     switch (currentStep) {


### PR DESCRIPTION
## Summary

This PR fixes a runtime error that occurred during the Skills step of the onboarding flow due to a missing `validateSkills()` helper.

The onboarding page referenced `validateSkills()` in multiple places, but the function was never defined, resulting in a `ReferenceError` that prevented users from completing onboarding.

##  Changes Made

- Added the missing `validateSkills()` helper in `src/pages/OnboardingPage.tsx`.
- Combined the existing `validateTechnicalSkills()` and `validateSoftSkills()` validation logic into a single reusable helper.
- Preserved the existing validation flow by returning the first validation error message encountered.
- Verified that all existing `validateSkills()` call sites now execute correctly without runtime errors.
closes #295 
